### PR TITLE
[FEAT]: 공통 응답 래퍼 및 글로벌 예외 처리기 추가

### DIFF
--- a/src/main/java/com/youthlink/server/common/ApiResponse.java
+++ b/src/main/java/com/youthlink/server/common/ApiResponse.java
@@ -1,0 +1,40 @@
+package com.youthlink.server.common;
+
+public class ApiResponse<T> {
+    private boolean success;
+    private String message;
+    private T data;
+
+    public ApiResponse() {
+    }
+
+    public ApiResponse(boolean success, String message, T data) {
+        this.success = success;
+        this.message = message;
+        this.data = data;
+    }
+
+    public boolean isSuccess() {
+        return success;
+    }
+
+    public void setSuccess(boolean success) {
+        this.success = success;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    public T getData() {
+        return data;
+    }
+
+    public void setData(T data) {
+        this.data = data;
+    }
+}

--- a/src/main/java/com/youthlink/server/common/GlobalExceptionHandler.java
+++ b/src/main/java/com/youthlink/server/common/GlobalExceptionHandler.java
@@ -1,0 +1,18 @@
+package com.youthlink.server.common;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<Void>> handleException(Exception e) {
+        ApiResponse<Void> response = new ApiResponse<>();
+        response.setSuccess(false);
+        response.setMessage("An unexpected error occurred: " + e.getMessage());
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(response);
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> 없음

## 📝작업 내용

> 프로젝트 공통 레이어 구성을 위한 응답 래퍼와 예외 처리기를 추가했습니다.

- **`ApiResponse<T>`**: 모든 API 응답에 사용할 제네릭 응답 래퍼 클래스
  - `success` (성공 여부), `message` (메시지), `data` (응답 데이터) 필드 포함
- **`GlobalExceptionHandler`**: `@RestControllerAdvice` 기반 글로벌 예외 처리
  - 예상치 못한 예외 발생 시 일관된 에러 응답 반환 (`500 Internal Server Error`)

### 스크린샷 (선택)

해당 없음 (백엔드 코드 변경)

## 💬리뷰 요구사항(선택)

> - `ApiResponse`에 정적 팩토리 메서드(`success()`, `error()`) 추가가 필요한지 검토 부탁드립니다.
> - `GlobalExceptionHandler`에 `MethodArgumentNotValidException` 등 세분화된 예외 처리 추가 여부에 대한 의견 부탁드립니다.
