### PR TITLE
[FEAT]: Spring Security 기본 설정 추가

### DIFF
--- a/src/main/java/com/youthlink/server/config/SecurityConfig.java
+++ b/src/main/java/com/youthlink/server/config/SecurityConfig.java
@@ -1,0 +1,32 @@
+package com.youthlink.server.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+
+import static org.springframework.security.config.Customizer.withDefaults;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+            .csrf(AbstractHttpConfigurer::disable)
+            .authorizeHttpRequests(auth -> auth
+                .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html").permitAll()
+                .requestMatchers("/h2-console/**").permitAll()
+                .anyRequest().authenticated()
+            )
+            .headers(headers -> headers.frameOptions(HeadersConfigurer.FrameOptionsConfig::disable))
+            .formLogin(withDefaults())
+            .httpBasic(withDefaults());
+
+        return http.build();
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> 없음

## 📝작업 내용

> Swagger UI 및 H2 콘솔 접근을 허용하는 Spring Security 기본 설정을 추가했습니다.

- **[SecurityConfig.java](cci:7://file:///Users/ryong/Desktop/Ryong/youthLink/BE/src/main/java/com/youthlink/server/config/SecurityConfig.java:0:0-0:0)**
  - CSRF 비활성화
  - Swagger 관련 경로 (`/v3/api-docs/**`, `/swagger-ui/**`, `/swagger-ui.html`) permitAll
  - H2 콘솔 경로 (`/h2-console/**`) permitAll
  - 나머지 요청은 인증 필요
  - H2 콘솔 iframe 허용을 위한 `frameOptions` 비활성화
  - 기본 formLogin, httpBasic 활성화 (추후 제거 예정)

### 스크린샷 (선택)

해당 없음

## 💬리뷰 요구사항(선택)

> - 추후 OAuth2 + JWT 필터 적용 시 `formLogin`과 `httpBasic`은 제거될 예정입니다.
> - 현재는 로컬 개발/Swagger 테스트 용도의 최소 설정입니다.
