### PR TITLE
[CHORE]: Spring Boot 버전 변경 및 의존성 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '4.0.3'
+	id 'org.springframework.boot' version '3.4.13'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -27,20 +27,17 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
-	implementation 'org.springframework.boot:spring-boot-starter-security-oauth2-client'
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
-	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
-	testImplementation 'org.springframework.boot:spring-boot-starter-security-oauth2-client-test'
-	testImplementation 'org.springframework.boot:spring-boot-starter-security-test'
-	testImplementation 'org.springframework.boot:spring-boot-starter-validation-test'
-	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

없음

## 📝작업 내용

> Spring Boot 4.0.3 -> 3.4.13으로 변경
> 의존성 명칭 정정 (3.4.x 호환):
spring-boot-starter-webmvc → spring-boot-starter-web
spring-boot-starter-security-oauth2-client → spring-boot-starter-oauth2-client
### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 
3.4.x 계열에서 존재하지 않는 4.0.x 전용 의존성 명칭들을 표준 명칭으로 수정하여 빌드 오류를 해결했습니다. ./gradlew build를 통해 컴파일 및 테스트 통과를 확인했으니 이 부분을 중점적으로 봐주세요.

