### PR TITLE
[Feat]: BaseTimeEntity 및 JPA Auditing 설정 추가

### DIFF
--- a/src/main/java/com/youthlink/server/ServerApplication.java
+++ b/src/main/java/com/youthlink/server/ServerApplication.java
@@ -2,7 +2,11 @@ package com.youthlink.server;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
+@EnableJpaAuditing
 @SpringBootApplication
 public class ServerApplication {
 

--- a/src/main/java/com/youthlink/server/common/BaseTimeEntity.java
+++ b/src/main/java/com/youthlink/server/common/BaseTimeEntity.java
@@ -1,0 +1,24 @@
+package com.youthlink.server.common;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #8 

## 📝작업 내용

> 모든 엔티티에서 공통으로 사용할 시간 추적 엔티티와 JPA Auditing 설정을 추가했습니다.

- **`BaseTimeEntity.java`**: `@MappedSuperclass` 기반 공통 엔티티
  - `createdAt` (생성 시각, 수정 불가)
  - `updatedAt` (수정 시각, 자동 갱신)
  - `@EntityListeners(AuditingEntityListener.class)` 적용
- **`ServerApplication.java`**:
  - `@EnableJpaAuditing` — JPA Auditing 활성화 (BaseTimeEntity 동작용)

### 스크린샷 (선택)

해당 없음

## 💬리뷰 요구사항(선택)

> 스케쥴링 관련 작업은 후에 관련 작업과 함께 진행하기 위해 제외하였습니다.
