### PR TITLE
[FEAT]: 회원 프로필 관리 API 구현

### DIFF
--- a/src/main/java/com/youthlink/server/member/Member.java
+++ b/src/main/java/com/youthlink/server/member/Member.java
@@ -1,0 +1,66 @@
+package com.youthlink.server.member;
+
+import com.youthlink.server.common.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Member extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String email;
+
+    private String name;
+
+    private Integer age;
+
+    private String region;
+
+    @Column(length = 50)
+    private String education;
+
+    @Column(length = 50)
+    private String employmentStatus;
+
+    @Column(length = 50)
+    private String incomeLevel;
+
+    private String profileImageUrl;
+
+    @Builder
+    public Member(String email, String name, Integer age, String region,
+            String education, String employmentStatus, String incomeLevel) {
+        this.email = email;
+        this.name = name;
+        this.age = age;
+        this.region = region;
+        this.education = education;
+        this.employmentStatus = employmentStatus;
+        this.incomeLevel = incomeLevel;
+    }
+
+    public void updateProfile(String name, Integer age, String region,
+            String education, String employmentStatus, String incomeLevel) {
+        if (name != null)
+            this.name = name;
+        if (age != null)
+            this.age = age;
+        if (region != null)
+            this.region = region;
+        if (education != null)
+            this.education = education;
+        if (employmentStatus != null)
+            this.employmentStatus = employmentStatus;
+        if (incomeLevel != null)
+            this.incomeLevel = incomeLevel;
+    }
+}

--- a/src/main/java/com/youthlink/server/member/MemberController.java
+++ b/src/main/java/com/youthlink/server/member/MemberController.java
@@ -1,0 +1,47 @@
+package com.youthlink.server.member;
+
+import com.youthlink.server.common.ApiResponse;
+import com.youthlink.server.member.dto.MemberResponse;
+import com.youthlink.server.member.dto.ProfileUpdateRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Member", description = "회원 프로필 관리 API")
+@RestController
+@RequestMapping("/api/members")
+@RequiredArgsConstructor
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @Operation(summary = "내 프로필 조회", description = "현재 로그인한 사용자의 프로필을 조회합니다")
+    @GetMapping("/me")
+    public ResponseEntity<ApiResponse<MemberResponse>> getMyProfile() {
+        // TODO: SecurityContext에서 인증된 사용자 ID 추출 (OAuth2 연동 후 변경)
+        Long memberId = 1L;
+        MemberResponse response = memberService.getMemberById(memberId);
+        return ResponseEntity.ok(new ApiResponse<>(true, "프로필 조회 성공", response));
+    }
+
+    @Operation(summary = "프로필 수정", description = "현재 로그인한 사용자의 프로필을 수정합니다")
+    @PutMapping("/me")
+    public ResponseEntity<ApiResponse<MemberResponse>> updateMyProfile(
+            @Valid @RequestBody ProfileUpdateRequest request) {
+        // TODO: SecurityContext에서 인증된 사용자 ID 추출 (OAuth2 연동 후 변경)
+        Long memberId = 1L;
+        MemberResponse response = memberService.updateProfile(memberId, request);
+        return ResponseEntity.ok(new ApiResponse<>(true, "프로필 수정 성공", response));
+    }
+
+    @Operation(summary = "회원 프로필 조회 (ID)", description = "회원 ID로 프로필을 조회합니다")
+    @GetMapping("/{memberId}")
+    public ResponseEntity<ApiResponse<MemberResponse>> getMemberProfile(
+            @PathVariable Long memberId) {
+        MemberResponse response = memberService.getMemberById(memberId);
+        return ResponseEntity.ok(new ApiResponse<>(true, "프로필 조회 성공", response));
+    }
+}

--- a/src/main/java/com/youthlink/server/member/MemberRepository.java
+++ b/src/main/java/com/youthlink/server/member/MemberRepository.java
@@ -1,0 +1,11 @@
+package com.youthlink.server.member;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+    Optional<Member> findByEmail(String email);
+
+    boolean existsByEmail(String email);
+}

--- a/src/main/java/com/youthlink/server/member/MemberService.java
+++ b/src/main/java/com/youthlink/server/member/MemberService.java
@@ -1,0 +1,43 @@
+package com.youthlink.server.member;
+
+import com.youthlink.server.member.dto.MemberResponse;
+import com.youthlink.server.member.dto.ProfileUpdateRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+
+    public MemberResponse getMemberById(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다. id=" + memberId));
+        return MemberResponse.from(member);
+    }
+
+    public MemberResponse getMemberByEmail(String email) {
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다. email=" + email));
+        return MemberResponse.from(member);
+    }
+
+    @Transactional
+    public MemberResponse updateProfile(Long memberId, ProfileUpdateRequest request) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다. id=" + memberId));
+
+        member.updateProfile(
+                request.getName(),
+                request.getAge(),
+                request.getRegion(),
+                request.getEducation(),
+                request.getEmploymentStatus(),
+                request.getIncomeLevel());
+
+        return MemberResponse.from(member);
+    }
+}

--- a/src/main/java/com/youthlink/server/member/MemberService.java
+++ b/src/main/java/com/youthlink/server/member/MemberService.java
@@ -2,42 +2,12 @@ package com.youthlink.server.member;
 
 import com.youthlink.server.member.dto.MemberResponse;
 import com.youthlink.server.member.dto.ProfileUpdateRequest;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
-@Service
-@RequiredArgsConstructor
-@Transactional(readOnly = true)
-public class MemberService {
+public interface MemberService {
 
-    private final MemberRepository memberRepository;
+    MemberResponse getMemberById(Long memberId);
 
-    public MemberResponse getMemberById(Long memberId) {
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다. id=" + memberId));
-        return MemberResponse.from(member);
-    }
+    MemberResponse getMemberByEmail(String email);
 
-    public MemberResponse getMemberByEmail(String email) {
-        Member member = memberRepository.findByEmail(email)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다. email=" + email));
-        return MemberResponse.from(member);
-    }
-
-    @Transactional
-    public MemberResponse updateProfile(Long memberId, ProfileUpdateRequest request) {
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다. id=" + memberId));
-
-        member.updateProfile(
-                request.getName(),
-                request.getAge(),
-                request.getRegion(),
-                request.getEducation(),
-                request.getEmploymentStatus(),
-                request.getIncomeLevel());
-
-        return MemberResponse.from(member);
-    }
+    MemberResponse updateProfile(Long memberId, ProfileUpdateRequest request);
 }

--- a/src/main/java/com/youthlink/server/member/MemberServiceImpl.java
+++ b/src/main/java/com/youthlink/server/member/MemberServiceImpl.java
@@ -1,0 +1,46 @@
+package com.youthlink.server.member;
+
+import com.youthlink.server.member.dto.MemberResponse;
+import com.youthlink.server.member.dto.ProfileUpdateRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MemberServiceImpl implements MemberService {
+
+    private final MemberRepository memberRepository;
+
+    @Override
+    public MemberResponse getMemberById(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다. id=" + memberId));
+        return MemberResponse.from(member);
+    }
+
+    @Override
+    public MemberResponse getMemberByEmail(String email) {
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다. email=" + email));
+        return MemberResponse.from(member);
+    }
+
+    @Override
+    @Transactional
+    public MemberResponse updateProfile(Long memberId, ProfileUpdateRequest request) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다. id=" + memberId));
+
+        member.updateProfile(
+                request.getName(),
+                request.getAge(),
+                request.getRegion(),
+                request.getEducation(),
+                request.getEmploymentStatus(),
+                request.getIncomeLevel());
+
+        return MemberResponse.from(member);
+    }
+}

--- a/src/main/java/com/youthlink/server/member/dto/MemberResponse.java
+++ b/src/main/java/com/youthlink/server/member/dto/MemberResponse.java
@@ -1,0 +1,32 @@
+package com.youthlink.server.member.dto;
+
+import com.youthlink.server.member.Member;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class MemberResponse {
+
+    private Long id;
+    private String email;
+    private String name;
+    private Integer age;
+    private String region;
+    private String education;
+    private String employmentStatus;
+    private String incomeLevel;
+
+    public static MemberResponse from(Member member) {
+        return MemberResponse.builder()
+                .id(member.getId())
+                .email(member.getEmail())
+                .name(member.getName())
+                .age(member.getAge())
+                .region(member.getRegion())
+                .education(member.getEducation())
+                .employmentStatus(member.getEmploymentStatus())
+                .incomeLevel(member.getIncomeLevel())
+                .build();
+    }
+}

--- a/src/main/java/com/youthlink/server/member/dto/ProfileUpdateRequest.java
+++ b/src/main/java/com/youthlink/server/member/dto/ProfileUpdateRequest.java
@@ -1,0 +1,26 @@
+package com.youthlink.server.member.dto;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ProfileUpdateRequest {
+
+    @Size(max = 50, message = "이름은 50자 이하여야 합니다")
+    private String name;
+
+    @Min(value = 1, message = "나이는 1 이상이어야 합니다")
+    private Integer age;
+
+    @Size(max = 100, message = "지역은 100자 이하여야 합니다")
+    private String region;
+
+    private String education;
+
+    private String employmentStatus;
+
+    private String incomeLevel;
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #9 

## 📝작업 내용

> 회원 프로필을 조회하고 수정하는 API를 구현했습니다.

- **`Member.java`**: 프로필 필드 포함 엔티티 (나이, 지역, 학력, 취업상태, 소득수준)
- **`MemberRepository.java`**: email 기반 조회
- **`MemberService.java`**: 프로필 조회(ID/이메일), 수정 비즈니스 로직
- **`MemberController.java`**: Swagger 적용
  - `GET /api/members/me` — 내 프로필 조회
  - `PUT /api/members/me` — 프로필 수정
  - `GET /api/members/{id}` — 회원 조회
- **DTOs**: `MemberResponse`, `ProfileUpdateRequest` (Validation 포함)

### 스크린샷 (선택)

해당 없음

## 💬리뷰 요구사항(선택)

> - `/me` 엔드포인트의 인증 사용자 추출은 주석 처리로 표시했습니다 (도영님의 OAuth2 연동 후 교체가 필요합니다.)
> - RAG 채팅에서 Member 엔티티의 필요성에 의하여 먼저 엔터티를 생성하게 되었는데, 도영님이 후에 oauth2/jwt 관련 작업을 하실 때 이 베이스를 활용하면 좋을 거 같습니다.
