### PR TITLE
[FIX]  EmbeddingModel 빈 생성 문제 해결

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,12 +22,11 @@ configurations {
 
 repositories {
 	mavenCentral()
-	maven { url 'https://repo.spring.io/milestone' }
 }
 
 dependencyManagement {
 	imports {
-		mavenBom "org.springframework.ai:spring-ai-bom:1.0.0"
+		mavenBom "org.springframework.ai:spring-ai-bom:1.1.1"
 	}
 }
 
@@ -44,15 +43,16 @@ dependencies {
 	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 	annotationProcessor 'org.projectlombok:lombok'
+
 	// JWT
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
 
-	// Spring AI - Google Gemini (채팅 + 임베딩 모델 자동 구성)
-	implementation 'org.springframework.ai:spring-ai-google-genai-spring-boot-starter'
-	// Spring AI - Chroma Vector Store (VectorStore Bean 자동 구성)
-	implementation 'org.springframework.ai:spring-ai-vectorstore-chroma-spring-boot-starter'
+	// Spring AI - Google GenAI (Gemini API Key 방식 채팅 + 임베딩)
+	implementation 'org.springframework.ai:spring-ai-starter-model-google-genai'
+	// Spring AI - Chroma Vector Store
+	implementation 'org.springframework.ai:spring-ai-starter-vector-store-chroma'
 
 	// XML 파싱 (온통청년 API 응답)
 	implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml'

--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,13 @@ configurations {
 
 repositories {
 	mavenCentral()
+	maven { url 'https://repo.spring.io/milestone' }
+}
+
+dependencyManagement {
+	imports {
+		mavenBom "org.springframework.ai:spring-ai-bom:1.0.0"
+	}
 }
 
 dependencies {
@@ -41,6 +48,14 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
+
+	// Spring AI - Google Gemini (채팅 + 임베딩 모델 자동 구성)
+	implementation 'org.springframework.ai:spring-ai-google-genai-spring-boot-starter'
+	// Spring AI - Chroma Vector Store (VectorStore Bean 자동 구성)
+	implementation 'org.springframework.ai:spring-ai-vectorstore-chroma-spring-boot-starter'
+
+	// XML 파싱 (온통청년 API 응답)
+	implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml'
 
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'

--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,7 @@ dependencies {
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
 
-	// Spring AI - Google GenAI (Gemini API Key 방식 채팅 + 임베딩)
+	// Spring AI - Google GenAI (Gemini 채팅 + 임베딩)
 	implementation 'org.springframework.ai:spring-ai-starter-model-google-genai'
 	// Spring AI - Chroma Vector Store
 	implementation 'org.springframework.ai:spring-ai-starter-vector-store-chroma'

--- a/src/main/java/com/youthlink/server/ServerApplication.java
+++ b/src/main/java/com/youthlink/server/ServerApplication.java
@@ -12,6 +12,7 @@ public class ServerApplication {
 
 	public static void main(String[] args) {
 		SpringApplication.run(ServerApplication.class, args);
-	}
+
+
 
 }

--- a/src/main/java/com/youthlink/server/ServerApplication.java
+++ b/src/main/java/com/youthlink/server/ServerApplication.java
@@ -12,7 +12,6 @@ public class ServerApplication {
 
 	public static void main(String[] args) {
 		SpringApplication.run(ServerApplication.class, args);
-
-
+	}
 
 }

--- a/src/main/java/com/youthlink/server/common/config/GeminiEmbeddingConfig.java
+++ b/src/main/java/com/youthlink/server/common/config/GeminiEmbeddingConfig.java
@@ -1,0 +1,83 @@
+package com.youthlink.server.common.config;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import org.springframework.ai.document.Document;
+import org.springframework.ai.embedding.Embedding;
+import org.springframework.ai.embedding.EmbeddingModel;
+import org.springframework.ai.embedding.EmbeddingRequest;
+import org.springframework.ai.embedding.EmbeddingResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestClient;
+
+import java.util.List;
+import java.util.stream.IntStream;
+
+@Configuration
+public class GeminiEmbeddingConfig {
+
+    @Bean
+    public EmbeddingModel embeddingModel(
+            @Value("${spring.ai.google.genai.embedding.api-key}") String apiKey,
+            @Value("${spring.ai.google.genai.embedding.options.model}") String model) {
+        RestClient restClient = RestClient.builder()
+                .baseUrl("https://generativelanguage.googleapis.com")
+                .build();
+        return new GeminiEmbeddingModel(restClient, apiKey, model);
+    }
+
+    static class GeminiEmbeddingModel implements EmbeddingModel {
+
+        private final RestClient restClient;
+        private final String apiKey;
+        private final String model;
+
+        GeminiEmbeddingModel(RestClient restClient, String apiKey, String model) {
+            this.restClient = restClient;
+            this.apiKey = apiKey;
+            this.model = model;
+        }
+
+        @Override
+        public float[] embed(Document document) {
+            return call(new EmbeddingRequest(List.of(document.getText()), null))
+                    .getResults().get(0).getOutput();
+        }
+
+        @Override
+        public EmbeddingResponse call(EmbeddingRequest request) {
+            List<EmbedRequest> requests = request.getInstructions().stream()
+                    .map(text -> new EmbedRequest(new EmbedContent(List.of(new EmbedPart(text)))))
+                    .toList();
+
+            BatchEmbedResponse response = restClient.post()
+                    .uri("/v1beta/models/{model}:batchEmbedContents?key={key}", model, apiKey)
+                    .body(new BatchEmbedRequest(requests))
+                    .retrieve()
+                    .body(BatchEmbedResponse.class);
+
+            List<Embedding> embeddings = IntStream.range(0, response.embeddings().size())
+                    .mapToObj(i -> {
+                        List<Double> vals = response.embeddings().get(i).values();
+                        float[] arr = new float[vals.size()];
+                        for (int j = 0; j < vals.size(); j++) arr[j] = vals.get(j).floatValue();
+                        return new Embedding(arr, i);
+                    })
+                    .toList();
+
+            return new EmbeddingResponse(embeddings);
+        }
+
+        record BatchEmbedRequest(List<EmbedRequest> requests) {}
+        record EmbedRequest(EmbedContent content) {}
+        record EmbedContent(List<EmbedPart> parts) {}
+        record EmbedPart(String text) {}
+
+        @JsonIgnoreProperties(ignoreUnknown = true)
+        record BatchEmbedResponse(List<EmbedValues> embeddings) {}
+
+        @JsonIgnoreProperties(ignoreUnknown = true)
+        record EmbedValues(List<Double> values) {}
+    }
+}

--- a/src/main/java/com/youthlink/server/common/config/LocalVectorStoreConfig.java
+++ b/src/main/java/com/youthlink/server/common/config/LocalVectorStoreConfig.java
@@ -1,0 +1,35 @@
+package com.youthlink.server.common.config;
+
+import org.springframework.ai.document.Document;
+import org.springframework.ai.vectorstore.SearchRequest;
+import org.springframework.ai.vectorstore.VectorStore;
+import org.springframework.ai.vectorstore.filter.Filter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+import java.util.List;
+
+@Configuration
+@Profile("local")
+public class LocalVectorStoreConfig {
+
+    @Bean
+    public VectorStore vectorStore() {
+        return new VectorStore() {
+            @Override
+            public void add(List<Document> documents) {}
+
+            @Override
+            public void delete(List<String> idList) {}
+
+            @Override
+            public void delete(Filter.Expression filterExpression) {}
+
+            @Override
+            public List<Document> similaritySearch(SearchRequest request) {
+                return List.of();
+            }
+        };
+    }
+}

--- a/src/main/java/com/youthlink/server/common/config/SecurityConfig.java
+++ b/src/main/java/com/youthlink/server/common/config/SecurityConfig.java
@@ -40,8 +40,14 @@ public class SecurityConfig {
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/", "/login/**", "/oauth2/**").permitAll()
+                        .requestMatchers(
+                                "/", "/login/**", "/oauth2/**",
+                                "/swagger-ui.html", "/swagger-ui/**", "/v3/api-docs/**",
+                                "/api/auth/**",
+                                "/h2-console/**"
+                        ).permitAll()
                         .anyRequest().authenticated())
+                .headers(headers -> headers.frameOptions(frame -> frame.disable()))
                 .exceptionHandling(conf -> conf
                     .authenticationEntryPoint(jwtAuthenticationEntryPoint)
                     .accessDeniedHandler(jwtAccessDeniedHandler)

--- a/src/main/java/com/youthlink/server/common/config/WebClientConfig.java
+++ b/src/main/java/com/youthlink/server/common/config/WebClientConfig.java
@@ -1,0 +1,21 @@
+package com.youthlink.server.common.config;
+
+import com.youthlink.server.domain.policy.config.YouthPolicyApiProperties;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestClient;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebClientConfig {
+
+    private final YouthPolicyApiProperties youthPolicyApiProperties;
+
+    @Bean
+    public RestClient youthPolicyRestClient() {
+        return RestClient.builder()
+                .baseUrl(youthPolicyApiProperties.getUrl())
+                .build();
+    }
+}

--- a/src/main/java/com/youthlink/server/domain/member/controller/MemberController.java
+++ b/src/main/java/com/youthlink/server/domain/member/controller/MemberController.java
@@ -12,6 +12,8 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "Member", description = "회원 프로필 관리 API")
@@ -25,20 +27,21 @@ public class MemberController {
 
     @Operation(summary = "내 프로필 조회", description = "현재 로그인한 사용자의 프로필을 조회합니다")
     @GetMapping("/me")
-    public ResponseEntity<ApiResponse<MemberResDto.MemberDetailDto>> getMyProfile() {
-        // TODO: SecurityContext에서 인증된 사용자 ID 추출 (OAuth2 연동 후 변경)
+    public ResponseEntity<ApiResponse<MemberResDto.MemberDetailDto>> getMyProfile(
+            @AuthenticationPrincipal UserDetails userDetails) {
         return ResponseEntity.status(MemberSuccessCode.MEMBER_OK.getStatus())
-                .body(ApiResponse.onSuccess(MemberSuccessCode.MEMBER_OK, memberQueryService.getMemberById(1L)));
+                .body(ApiResponse.onSuccess(MemberSuccessCode.MEMBER_OK,
+                        memberQueryService.getMemberByEmail(userDetails.getUsername())));
     }
 
     @Operation(summary = "프로필 수정", description = "현재 로그인한 사용자의 프로필을 수정합니다")
     @PutMapping("/me")
     public ResponseEntity<ApiResponse<MemberResDto.MemberDetailDto>> updateMyProfile(
+            @AuthenticationPrincipal UserDetails userDetails,
             @Valid @RequestBody MemberReqDto.ProfileUpdateDto request) {
-        // TODO: SecurityContext에서 인증된 사용자 ID 추출 (OAuth2 연동 후 변경)
         return ResponseEntity.status(MemberSuccessCode.MEMBER_UPDATE_SUCCESS.getStatus())
                 .body(ApiResponse.onSuccess(MemberSuccessCode.MEMBER_UPDATE_SUCCESS,
-                        memberCommandService.updateProfile(1L, request)));
+                        memberCommandService.updateProfileByEmail(userDetails.getUsername(), request)));
     }
 
     @Operation(summary = "회원 프로필 조회 (ID)", description = "회원 ID로 프로필을 조회합니다")

--- a/src/main/java/com/youthlink/server/domain/member/service/MemberCommandService.java
+++ b/src/main/java/com/youthlink/server/domain/member/service/MemberCommandService.java
@@ -7,5 +7,7 @@ import com.youthlink.server.domain.member.entity.Member;
 public interface MemberCommandService {
     MemberResDto.MemberDetailDto updateProfile(Long memberId, MemberReqDto.ProfileUpdateDto request);
 
+    MemberResDto.MemberDetailDto updateProfileByEmail(String email, MemberReqDto.ProfileUpdateDto request);
+
     Member getOrCreateMember(String email, String name);
 }

--- a/src/main/java/com/youthlink/server/domain/member/service/MemberCommandServiceImpl.java
+++ b/src/main/java/com/youthlink/server/domain/member/service/MemberCommandServiceImpl.java
@@ -36,6 +36,22 @@ public class MemberCommandServiceImpl implements MemberCommandService {
     }
 
     @Override
+    public MemberResDto.MemberDetailDto updateProfileByEmail(String email, MemberReqDto.ProfileUpdateDto request) {
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
+
+        member.updateProfile(
+                request.name(),
+                request.age(),
+                request.region(),
+                request.education(),
+                request.employmentStatus(),
+                request.incomeLevel());
+
+        return MemberConverter.toMemberDetailDto(member);
+    }
+
+    @Override
     public Member getOrCreateMember(String email, String name) {
         Optional<Member> memberOptional = memberRepository.findByEmail(email);
         if (memberOptional.isPresent()) {

--- a/src/main/java/com/youthlink/server/domain/notification/code/NotificationErrorCode.java
+++ b/src/main/java/com/youthlink/server/domain/notification/code/NotificationErrorCode.java
@@ -1,0 +1,17 @@
+package com.youthlink.server.domain.notification.code;
+
+import com.youthlink.server.common.apipayload.code.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum NotificationErrorCode implements BaseErrorCode {
+    NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "NOTI404", "알림을 찾을 수 없습니다"),
+    NOTIFICATION_FORBIDDEN(HttpStatus.FORBIDDEN, "NOTI403", "해당 알림에 대한 권한이 없습니다");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/youthlink/server/domain/notification/code/NotificationSuccessCode.java
+++ b/src/main/java/com/youthlink/server/domain/notification/code/NotificationSuccessCode.java
@@ -1,0 +1,17 @@
+package com.youthlink.server.domain.notification.code;
+
+import com.youthlink.server.common.apipayload.code.BaseSuccessCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum NotificationSuccessCode implements BaseSuccessCode {
+    NOTIFICATION_LIST_OK(HttpStatus.OK, "NOTI200", "알림 목록 조회 성공"),
+    NOTIFICATION_READ_OK(HttpStatus.OK, "NOTI200", "알림 읽음 처리 성공");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/youthlink/server/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/youthlink/server/domain/notification/controller/NotificationController.java
@@ -1,0 +1,43 @@
+package com.youthlink.server.domain.notification.controller;
+
+import com.youthlink.server.common.apipayload.ApiResponse;
+import com.youthlink.server.domain.notification.code.NotificationSuccessCode;
+import com.youthlink.server.domain.notification.dto.NotificationResDto;
+import com.youthlink.server.domain.notification.service.NotificationService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "Notification", description = "알림 API")
+@RestController
+@RequestMapping("/api/notifications")
+@RequiredArgsConstructor
+public class NotificationController {
+
+    private final NotificationService notificationService;
+
+    @Operation(summary = "내 알림 목록 조회", description = "현재 사용자의 알림을 최신순으로 조회합니다")
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<NotificationResDto.NotificationDto>>> getMyNotifications(
+            @AuthenticationPrincipal UserDetails userDetails) {
+        return ResponseEntity.status(NotificationSuccessCode.NOTIFICATION_LIST_OK.getStatus())
+                .body(ApiResponse.onSuccess(NotificationSuccessCode.NOTIFICATION_LIST_OK,
+                        notificationService.getMyNotifications(userDetails.getUsername())));
+    }
+
+    @Operation(summary = "알림 읽음 처리", description = "특정 알림을 읽음 상태로 변경합니다")
+    @PatchMapping("/{notificationId}/read")
+    public ResponseEntity<ApiResponse<Void>> markAsRead(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @PathVariable Long notificationId) {
+        notificationService.markAsRead(userDetails.getUsername(), notificationId);
+        return ResponseEntity.status(NotificationSuccessCode.NOTIFICATION_READ_OK.getStatus())
+                .body(ApiResponse.onSuccess(NotificationSuccessCode.NOTIFICATION_READ_OK, null));
+    }
+}

--- a/src/main/java/com/youthlink/server/domain/notification/converter/NotificationConverter.java
+++ b/src/main/java/com/youthlink/server/domain/notification/converter/NotificationConverter.java
@@ -1,0 +1,19 @@
+package com.youthlink.server.domain.notification.converter;
+
+import com.youthlink.server.domain.notification.dto.NotificationResDto;
+import com.youthlink.server.domain.notification.entity.Notification;
+
+public class NotificationConverter {
+
+    public static NotificationResDto.NotificationDto toNotificationDto(Notification notification) {
+        return NotificationResDto.NotificationDto.builder()
+                .id(notification.getId())
+                .title(notification.getTitle())
+                .content(notification.getContent())
+                .read(notification.isRead())
+                .policyId(notification.getPolicy() != null ? notification.getPolicy().getId() : null)
+                .policyName(notification.getPolicy() != null ? notification.getPolicy().getPolyBizSjnm() : null)
+                .createdAt(notification.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/youthlink/server/domain/notification/dto/NotificationResDto.java
+++ b/src/main/java/com/youthlink/server/domain/notification/dto/NotificationResDto.java
@@ -1,0 +1,19 @@
+package com.youthlink.server.domain.notification.dto;
+
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+public class NotificationResDto {
+
+    @Builder
+    public record NotificationDto(
+            Long id,
+            String title,
+            String content,
+            boolean read,
+            Long policyId,
+            String policyName,
+            LocalDateTime createdAt
+    ) {}
+}

--- a/src/main/java/com/youthlink/server/domain/notification/entity/Notification.java
+++ b/src/main/java/com/youthlink/server/domain/notification/entity/Notification.java
@@ -1,0 +1,41 @@
+package com.youthlink.server.domain.notification.entity;
+
+import com.youthlink.server.common.base.BaseTimeEntity;
+import com.youthlink.server.domain.member.entity.Member;
+import com.youthlink.server.domain.policy.entity.Policy;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Notification extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "policy_id")
+    private Policy policy;
+
+    @Column(nullable = false, length = 200)
+    private String title;
+
+    @Lob
+    private String content;
+
+    @Column(nullable = false)
+    @Builder.Default
+    private boolean read = false;
+
+    public void markAsRead() {
+        this.read = true;
+    }
+}

--- a/src/main/java/com/youthlink/server/domain/notification/exception/NotificationException.java
+++ b/src/main/java/com/youthlink/server/domain/notification/exception/NotificationException.java
@@ -1,0 +1,10 @@
+package com.youthlink.server.domain.notification.exception;
+
+import com.youthlink.server.common.apipayload.code.BaseErrorCode;
+import com.youthlink.server.common.apipayload.exception.GeneralException;
+
+public class NotificationException extends GeneralException {
+    public NotificationException(BaseErrorCode code) {
+        super(code);
+    }
+}

--- a/src/main/java/com/youthlink/server/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/youthlink/server/domain/notification/repository/NotificationRepository.java
@@ -1,0 +1,13 @@
+package com.youthlink.server.domain.notification.repository;
+
+import com.youthlink.server.domain.member.entity.Member;
+import com.youthlink.server.domain.notification.entity.Notification;
+import com.youthlink.server.domain.policy.entity.Policy;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+    List<Notification> findByMemberOrderByCreatedAtDesc(Member member);
+    boolean existsByMemberAndPolicy(Member member, Policy policy);
+}

--- a/src/main/java/com/youthlink/server/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/youthlink/server/domain/notification/service/NotificationService.java
@@ -1,0 +1,17 @@
+package com.youthlink.server.domain.notification.service;
+
+import com.youthlink.server.domain.notification.dto.NotificationResDto;
+import com.youthlink.server.domain.policy.entity.Policy;
+
+import java.util.List;
+
+public interface NotificationService {
+    /**
+     * 신규/변경된 정책 목록에 대해 활성 구독 중인 사용자와 매칭하여 알림을 생성한다.
+     */
+    void generateNotifications(List<Policy> changedPolicies);
+
+    List<NotificationResDto.NotificationDto> getMyNotifications(String email);
+
+    void markAsRead(String email, Long notificationId);
+}

--- a/src/main/java/com/youthlink/server/domain/notification/service/NotificationServiceImpl.java
+++ b/src/main/java/com/youthlink/server/domain/notification/service/NotificationServiceImpl.java
@@ -1,0 +1,111 @@
+package com.youthlink.server.domain.notification.service;
+
+import com.youthlink.server.domain.member.code.MemberErrorCode;
+import com.youthlink.server.domain.member.entity.Member;
+import com.youthlink.server.domain.member.exception.MemberException;
+import com.youthlink.server.domain.member.repository.MemberRepository;
+import com.youthlink.server.domain.notification.code.NotificationErrorCode;
+import com.youthlink.server.domain.notification.converter.NotificationConverter;
+import com.youthlink.server.domain.notification.dto.NotificationResDto;
+import com.youthlink.server.domain.notification.entity.Notification;
+import com.youthlink.server.domain.notification.exception.NotificationException;
+import com.youthlink.server.domain.notification.repository.NotificationRepository;
+import com.youthlink.server.domain.policy.entity.Policy;
+import com.youthlink.server.domain.policyalert.entity.PolicyAlert;
+import com.youthlink.server.domain.policyalert.repository.PolicyAlertRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class NotificationServiceImpl implements NotificationService {
+
+    private final NotificationRepository notificationRepository;
+    private final PolicyAlertRepository policyAlertRepository;
+    private final MemberRepository memberRepository;
+
+    @Override
+    public void generateNotifications(List<Policy> changedPolicies) {
+        if (changedPolicies == null || changedPolicies.isEmpty()) return;
+
+        List<PolicyAlert> activeAlerts = policyAlertRepository.findAllByActiveTrue();
+
+        for (Policy policy : changedPolicies) {
+            for (PolicyAlert alert : activeAlerts) {
+                if (!matchesPolicy(alert, policy)) continue;
+                if (notificationRepository.existsByMemberAndPolicy(alert.getMember(), policy)) continue;
+
+                Notification notification = Notification.builder()
+                        .member(alert.getMember())
+                        .policy(policy)
+                        .title("[새 정책] " + nullToEmpty(policy.getPolyBizSjnm()))
+                        .content(buildContent(policy))
+                        .build();
+                notificationRepository.save(notification);
+            }
+        }
+
+        log.info("알림 매칭 완료 - 대상 정책 {}건", changedPolicies.size());
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<NotificationResDto.NotificationDto> getMyNotifications(String email) {
+        Member member = findMember(email);
+        return notificationRepository.findByMemberOrderByCreatedAtDesc(member).stream()
+                .map(NotificationConverter::toNotificationDto)
+                .toList();
+    }
+
+    @Override
+    public void markAsRead(String email, Long notificationId) {
+        Notification notification = notificationRepository.findById(notificationId)
+                .orElseThrow(() -> new NotificationException(NotificationErrorCode.NOTIFICATION_NOT_FOUND));
+
+        if (!notification.getMember().getEmail().equals(email)) {
+            throw new NotificationException(NotificationErrorCode.NOTIFICATION_FORBIDDEN);
+        }
+
+        notification.markAsRead();
+    }
+
+    private boolean matchesPolicy(PolicyAlert alert, Policy policy) {
+        String keyword = alert.getKeyword();
+        boolean keywordMatch =
+                contains(policy.getPolyBizSjnm(), keyword) ||
+                contains(policy.getSporCn(), keyword) ||
+                contains(policy.getPolyItcnCn(), keyword);
+
+        String alertRegion = alert.getRegion();
+        boolean regionMatch = alertRegion == null || alertRegion.isBlank() ||
+                contains(policy.getCtpvNm(), alertRegion);
+
+        return keywordMatch && regionMatch;
+    }
+
+    private boolean contains(String text, String keyword) {
+        return text != null && keyword != null && text.contains(keyword);
+    }
+
+    private String buildContent(Policy policy) {
+        return String.format("기관: %s | 지역: %s | 신청기간: %s",
+                nullToEmpty(policy.getCnsgNmor()),
+                nullToEmpty(policy.getCtpvNm()),
+                nullToEmpty(policy.getRqutPrdCn()));
+    }
+
+    private String nullToEmpty(String value) {
+        return value != null ? value : "";
+    }
+
+    private Member findMember(String email) {
+        return memberRepository.findByEmail(email)
+                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/youthlink/server/domain/policy/code/PolicyErrorCode.java
+++ b/src/main/java/com/youthlink/server/domain/policy/code/PolicyErrorCode.java
@@ -1,0 +1,18 @@
+package com.youthlink.server.domain.policy.code;
+
+import com.youthlink.server.common.apipayload.code.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum PolicyErrorCode implements BaseErrorCode {
+    POLICY_NOT_FOUND(HttpStatus.NOT_FOUND, "POLICY404", "정책을 찾을 수 없습니다"),
+    POLICY_FETCH_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "POLICY500", "정책 데이터 수집에 실패했습니다"),
+    POLICY_EMBED_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "POLICY500", "정책 임베딩에 실패했습니다");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/youthlink/server/domain/policy/code/PolicySuccessCode.java
+++ b/src/main/java/com/youthlink/server/domain/policy/code/PolicySuccessCode.java
@@ -1,0 +1,18 @@
+package com.youthlink.server.domain.policy.code;
+
+import com.youthlink.server.common.apipayload.code.BaseSuccessCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum PolicySuccessCode implements BaseSuccessCode {
+    POLICY_LIST_OK(HttpStatus.OK, "POLICY200", "정책 목록 조회 성공"),
+    POLICY_DETAIL_OK(HttpStatus.OK, "POLICY200", "정책 상세 조회 성공"),
+    POLICY_SYNC_OK(HttpStatus.OK, "POLICY200", "정책 동기화 성공");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/youthlink/server/domain/policy/config/YouthPolicyApiProperties.java
+++ b/src/main/java/com/youthlink/server/domain/policy/config/YouthPolicyApiProperties.java
@@ -1,0 +1,15 @@
+package com.youthlink.server.domain.policy.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "youth-center.api")
+public class YouthPolicyApiProperties {
+    private String url;
+    private String key;
+}

--- a/src/main/java/com/youthlink/server/domain/policy/controller/PolicyController.java
+++ b/src/main/java/com/youthlink/server/domain/policy/controller/PolicyController.java
@@ -1,0 +1,56 @@
+package com.youthlink.server.domain.policy.controller;
+
+import com.youthlink.server.common.apipayload.ApiResponse;
+import com.youthlink.server.domain.policy.code.PolicyErrorCode;
+import com.youthlink.server.domain.policy.code.PolicySuccessCode;
+import com.youthlink.server.domain.policy.converter.PolicyConverter;
+import com.youthlink.server.domain.policy.dto.PolicyResDto;
+import com.youthlink.server.domain.policy.entity.Policy;
+import com.youthlink.server.domain.policy.exception.PolicyException;
+import com.youthlink.server.domain.policy.repository.PolicyRepository;
+import com.youthlink.server.domain.policy.scheduler.DataPipelineScheduler;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "Policy", description = "청년 정책 API")
+@RestController
+@RequiredArgsConstructor
+public class PolicyController {
+
+    private final PolicyRepository policyRepository;
+    private final DataPipelineScheduler dataPipelineScheduler;
+
+    @Operation(summary = "정책 목록 조회", description = "수집된 청년 정책 전체 목록을 조회합니다")
+    @GetMapping("/api/policies")
+    public ResponseEntity<ApiResponse<List<PolicyResDto.PolicySummaryDto>>> getPolicies() {
+        List<PolicyResDto.PolicySummaryDto> result = policyRepository.findAll().stream()
+                .map(PolicyConverter::toSummaryDto)
+                .toList();
+        return ResponseEntity.status(PolicySuccessCode.POLICY_LIST_OK.getStatus())
+                .body(ApiResponse.onSuccess(PolicySuccessCode.POLICY_LIST_OK, result));
+    }
+
+    @Operation(summary = "정책 상세 조회", description = "정책 ID로 청년 정책 상세 내용을 조회합니다")
+    @GetMapping("/api/policies/{policyId}")
+    public ResponseEntity<ApiResponse<PolicyResDto.PolicyDetailDto>> getPolicy(
+            @PathVariable Long policyId) {
+        Policy policy = policyRepository.findById(policyId)
+                .orElseThrow(() -> new PolicyException(PolicyErrorCode.POLICY_NOT_FOUND));
+        return ResponseEntity.status(PolicySuccessCode.POLICY_DETAIL_OK.getStatus())
+                .body(ApiResponse.onSuccess(PolicySuccessCode.POLICY_DETAIL_OK,
+                        PolicyConverter.toDetailDto(policy)));
+    }
+
+    @Operation(summary = "정책 수동 동기화", description = "온통청년 API에서 정책을 즉시 수집하고 Chroma에 임베딩합니다")
+    @PostMapping("/api/admin/policies/sync")
+    public ResponseEntity<ApiResponse<Void>> syncPolicies() {
+        dataPipelineScheduler.syncManually();
+        return ResponseEntity.status(PolicySuccessCode.POLICY_SYNC_OK.getStatus())
+                .body(ApiResponse.onSuccess(PolicySuccessCode.POLICY_SYNC_OK, null));
+    }
+}

--- a/src/main/java/com/youthlink/server/domain/policy/converter/PolicyConverter.java
+++ b/src/main/java/com/youthlink/server/domain/policy/converter/PolicyConverter.java
@@ -1,0 +1,55 @@
+package com.youthlink.server.domain.policy.converter;
+
+import com.youthlink.server.domain.policy.dto.PolicyResDto;
+import com.youthlink.server.domain.policy.dto.YouthPolicyResponse;
+import com.youthlink.server.domain.policy.entity.Policy;
+
+public class PolicyConverter {
+
+    public static Policy toPolicy(YouthPolicyResponse.PolicyItem item) {
+        return Policy.builder()
+                .bizId(item.getBizId())
+                .polyBizSjnm(item.getPolyBizSjnm())
+                .polyItcnCn(item.getPolyItcnCn())
+                .sporCn(item.getSporCn())
+                .rqutPrdCn(item.getRqutPrdCn())
+                .ageInfo(item.getAgeInfo())
+                .empmSttsCd(item.getEmpmSttsCd())
+                .accrRqisCd(item.getAccrRqisCd())
+                .incmRqisCn(item.getIncmRqisCn())
+                .cnsgNmor(item.getCnsgNmor())
+                .polyUrl(item.getPolyUrl())
+                .ctpvNm(item.getCtpvNm())
+                .build();
+    }
+
+    public static PolicyResDto.PolicySummaryDto toSummaryDto(Policy policy) {
+        return PolicyResDto.PolicySummaryDto.builder()
+                .id(policy.getId())
+                .bizId(policy.getBizId())
+                .polyBizSjnm(policy.getPolyBizSjnm())
+                .cnsgNmor(policy.getCnsgNmor())
+                .ctpvNm(policy.getCtpvNm())
+                .ageInfo(policy.getAgeInfo())
+                .polyUrl(policy.getPolyUrl())
+                .build();
+    }
+
+    public static PolicyResDto.PolicyDetailDto toDetailDto(Policy policy) {
+        return PolicyResDto.PolicyDetailDto.builder()
+                .id(policy.getId())
+                .bizId(policy.getBizId())
+                .polyBizSjnm(policy.getPolyBizSjnm())
+                .polyItcnCn(policy.getPolyItcnCn())
+                .sporCn(policy.getSporCn())
+                .rqutPrdCn(policy.getRqutPrdCn())
+                .ageInfo(policy.getAgeInfo())
+                .empmSttsCd(policy.getEmpmSttsCd())
+                .accrRqisCd(policy.getAccrRqisCd())
+                .incmRqisCn(policy.getIncmRqisCn())
+                .cnsgNmor(policy.getCnsgNmor())
+                .polyUrl(policy.getPolyUrl())
+                .ctpvNm(policy.getCtpvNm())
+                .build();
+    }
+}

--- a/src/main/java/com/youthlink/server/domain/policy/dto/PolicyResDto.java
+++ b/src/main/java/com/youthlink/server/domain/policy/dto/PolicyResDto.java
@@ -1,0 +1,34 @@
+package com.youthlink.server.domain.policy.dto;
+
+import lombok.Builder;
+
+public class PolicyResDto {
+
+    @Builder
+    public record PolicySummaryDto(
+            Long id,
+            String bizId,
+            String polyBizSjnm,
+            String cnsgNmor,
+            String ctpvNm,
+            String ageInfo,
+            String polyUrl
+    ) {}
+
+    @Builder
+    public record PolicyDetailDto(
+            Long id,
+            String bizId,
+            String polyBizSjnm,
+            String polyItcnCn,
+            String sporCn,
+            String rqutPrdCn,
+            String ageInfo,
+            String empmSttsCd,
+            String accrRqisCd,
+            String incmRqisCn,
+            String cnsgNmor,
+            String polyUrl,
+            String ctpvNm
+    ) {}
+}

--- a/src/main/java/com/youthlink/server/domain/policy/dto/YouthPolicyResponse.java
+++ b/src/main/java/com/youthlink/server/domain/policy/dto/YouthPolicyResponse.java
@@ -1,0 +1,39 @@
+package com.youthlink.server.domain.policy.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JacksonXmlRootElement(localName = "response")
+public class YouthPolicyResponse {
+
+    @JacksonXmlElementWrapper(useWrapping = false)
+    @JsonProperty("youthPolicy")
+    private List<PolicyItem> youthPolicies;
+
+    @Data
+    @NoArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class PolicyItem {
+        private String bizId;
+        private String polyBizSjnm;
+        private String polyItcnCn;
+        private String sporCn;
+        private String rqutPrdCn;
+        private String ageInfo;
+        private String empmSttsCd;
+        private String accrRqisCd;
+        private String incmRqisCn;
+        private String cnsgNmor;
+        private String polyUrl;
+        private String ctpvNm;
+    }
+}

--- a/src/main/java/com/youthlink/server/domain/policy/entity/Policy.java
+++ b/src/main/java/com/youthlink/server/domain/policy/entity/Policy.java
@@ -1,0 +1,68 @@
+package com.youthlink.server.domain.policy.entity;
+
+import com.youthlink.server.common.base.BaseTimeEntity;
+import com.youthlink.server.domain.policy.dto.YouthPolicyResponse;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Policy extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(unique = true, nullable = false, length = 50)
+    private String bizId;
+
+    @Column(length = 200)
+    private String polyBizSjnm;
+
+    @Lob
+    private String polyItcnCn;
+
+    @Lob
+    private String sporCn;
+
+    @Column(length = 500)
+    private String rqutPrdCn;
+
+    @Column(length = 100)
+    private String ageInfo;
+
+    @Column(length = 100)
+    private String empmSttsCd;
+
+    @Column(length = 100)
+    private String accrRqisCd;
+
+    @Lob
+    private String incmRqisCn;
+
+    @Column(length = 200)
+    private String cnsgNmor;
+
+    @Column(length = 500)
+    private String polyUrl;
+
+    @Column(length = 50)
+    private String ctpvNm;
+
+    public void update(YouthPolicyResponse.PolicyItem item) {
+        this.polyBizSjnm = item.getPolyBizSjnm();
+        this.polyItcnCn = item.getPolyItcnCn();
+        this.sporCn = item.getSporCn();
+        this.rqutPrdCn = item.getRqutPrdCn();
+        this.ageInfo = item.getAgeInfo();
+        this.empmSttsCd = item.getEmpmSttsCd();
+        this.accrRqisCd = item.getAccrRqisCd();
+        this.incmRqisCn = item.getIncmRqisCn();
+        this.cnsgNmor = item.getCnsgNmor();
+        this.polyUrl = item.getPolyUrl();
+        this.ctpvNm = item.getCtpvNm();
+    }
+}

--- a/src/main/java/com/youthlink/server/domain/policy/exception/PolicyException.java
+++ b/src/main/java/com/youthlink/server/domain/policy/exception/PolicyException.java
@@ -1,0 +1,10 @@
+package com.youthlink.server.domain.policy.exception;
+
+import com.youthlink.server.common.apipayload.code.BaseErrorCode;
+import com.youthlink.server.common.apipayload.exception.GeneralException;
+
+public class PolicyException extends GeneralException {
+    public PolicyException(BaseErrorCode code) {
+        super(code);
+    }
+}

--- a/src/main/java/com/youthlink/server/domain/policy/repository/PolicyRepository.java
+++ b/src/main/java/com/youthlink/server/domain/policy/repository/PolicyRepository.java
@@ -1,0 +1,10 @@
+package com.youthlink.server.domain.policy.repository;
+
+import com.youthlink.server.domain.policy.entity.Policy;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface PolicyRepository extends JpaRepository<Policy, Long> {
+    Optional<Policy> findByBizId(String bizId);
+}

--- a/src/main/java/com/youthlink/server/domain/policy/scheduler/DataPipelineScheduler.java
+++ b/src/main/java/com/youthlink/server/domain/policy/scheduler/DataPipelineScheduler.java
@@ -1,0 +1,47 @@
+package com.youthlink.server.domain.policy.scheduler;
+
+import com.youthlink.server.domain.policy.entity.Policy;
+import com.youthlink.server.domain.policy.service.PolicyEmbeddingService;
+import com.youthlink.server.domain.policy.service.PolicyFetchService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DataPipelineScheduler {
+
+    private final PolicyFetchService policyFetchService;
+    private final PolicyEmbeddingService policyEmbeddingService;
+
+    /**
+     * 매일 새벽 2시에 온통청년 정책 데이터를 수집하고 Chroma에 임베딩한다.
+     * 신규/변경된 정책만 반환받아 알림 매칭에 활용한다.
+     */
+    @Scheduled(cron = "0 0 2 * * *")
+    public void fetchAndEmbed() {
+        log.info("정책 데이터 파이프라인 시작");
+        try {
+            List<Policy> changedPolicies = policyFetchService.fetchAndSave();
+            policyEmbeddingService.embedPolicies(changedPolicies);
+            log.info("정책 데이터 파이프라인 완료 - 처리 {}건", changedPolicies.size());
+        } catch (Exception e) {
+            log.error("정책 데이터 파이프라인 실패: {}", e.getMessage());
+        }
+    }
+
+    /**
+     * 수동 동기화 트리거 (POST /api/admin/policies/sync 에서 호출)
+     */
+    public List<Policy> syncManually() {
+        log.info("정책 수동 동기화 시작");
+        List<Policy> changedPolicies = policyFetchService.fetchAndSave();
+        policyEmbeddingService.embedPolicies(changedPolicies);
+        log.info("정책 수동 동기화 완료 - 처리 {}건", changedPolicies.size());
+        return changedPolicies;
+    }
+}

--- a/src/main/java/com/youthlink/server/domain/policy/scheduler/DataPipelineScheduler.java
+++ b/src/main/java/com/youthlink/server/domain/policy/scheduler/DataPipelineScheduler.java
@@ -1,5 +1,6 @@
 package com.youthlink.server.domain.policy.scheduler;
 
+import com.youthlink.server.domain.notification.service.NotificationService;
 import com.youthlink.server.domain.policy.entity.Policy;
 import com.youthlink.server.domain.policy.service.PolicyEmbeddingService;
 import com.youthlink.server.domain.policy.service.PolicyFetchService;
@@ -17,6 +18,7 @@ public class DataPipelineScheduler {
 
     private final PolicyFetchService policyFetchService;
     private final PolicyEmbeddingService policyEmbeddingService;
+    private final NotificationService notificationService;
 
     /**
      * 매일 새벽 2시에 온통청년 정책 데이터를 수집하고 Chroma에 임베딩한다.
@@ -28,6 +30,7 @@ public class DataPipelineScheduler {
         try {
             List<Policy> changedPolicies = policyFetchService.fetchAndSave();
             policyEmbeddingService.embedPolicies(changedPolicies);
+            notificationService.generateNotifications(changedPolicies);
             log.info("정책 데이터 파이프라인 완료 - 처리 {}건", changedPolicies.size());
         } catch (Exception e) {
             log.error("정책 데이터 파이프라인 실패: {}", e.getMessage());
@@ -41,6 +44,7 @@ public class DataPipelineScheduler {
         log.info("정책 수동 동기화 시작");
         List<Policy> changedPolicies = policyFetchService.fetchAndSave();
         policyEmbeddingService.embedPolicies(changedPolicies);
+        notificationService.generateNotifications(changedPolicies);
         log.info("정책 수동 동기화 완료 - 처리 {}건", changedPolicies.size());
         return changedPolicies;
     }

--- a/src/main/java/com/youthlink/server/domain/policy/service/PolicyEmbeddingService.java
+++ b/src/main/java/com/youthlink/server/domain/policy/service/PolicyEmbeddingService.java
@@ -1,0 +1,13 @@
+package com.youthlink.server.domain.policy.service;
+
+import com.youthlink.server.domain.policy.entity.Policy;
+
+import java.util.List;
+
+public interface PolicyEmbeddingService {
+    /**
+     * Policy 목록을 Spring AI Document로 변환하여 Chroma VectorStore에 upsert한다.
+     * Document ID는 bizId로 고정하여 중복 적재를 방지한다.
+     */
+    void embedPolicies(List<Policy> policies);
+}

--- a/src/main/java/com/youthlink/server/domain/policy/service/PolicyEmbeddingServiceImpl.java
+++ b/src/main/java/com/youthlink/server/domain/policy/service/PolicyEmbeddingServiceImpl.java
@@ -1,0 +1,87 @@
+package com.youthlink.server.domain.policy.service;
+
+import com.youthlink.server.domain.policy.code.PolicyErrorCode;
+import com.youthlink.server.domain.policy.entity.Policy;
+import com.youthlink.server.domain.policy.exception.PolicyException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.ai.document.Document;
+import org.springframework.ai.vectorstore.VectorStore;
+import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PolicyEmbeddingServiceImpl implements PolicyEmbeddingService {
+
+    private final VectorStore vectorStore;
+
+    @Override
+    public void embedPolicies(List<Policy> policies) {
+        if (policies == null || policies.isEmpty()) return;
+
+        List<Document> documents = policies.stream()
+                .filter(p -> p.getBizId() != null)
+                .map(this::toDocument)
+                .filter(Objects::nonNull)
+                .toList();
+
+        if (documents.isEmpty()) return;
+
+        try {
+            vectorStore.add(documents);
+            log.info("Chroma 임베딩 완료 - {}건", documents.size());
+        } catch (Exception e) {
+            log.error("Chroma 임베딩 실패: {}", e.getMessage());
+            throw new PolicyException(PolicyErrorCode.POLICY_EMBED_FAILED);
+        }
+    }
+
+    private Document toDocument(Policy policy) {
+        try {
+            String content = String.format("""
+                    정책명: %s
+                    정책소개: %s
+                    지원내용: %s
+                    신청기간: %s
+                    나이조건: %s
+                    주관기관: %s
+                    지역: %s
+                    """,
+                    nullToEmpty(policy.getPolyBizSjnm()),
+                    nullToEmpty(policy.getPolyItcnCn()),
+                    nullToEmpty(policy.getSporCn()),
+                    nullToEmpty(policy.getRqutPrdCn()),
+                    nullToEmpty(policy.getAgeInfo()),
+                    nullToEmpty(policy.getCnsgNmor()),
+                    nullToEmpty(policy.getCtpvNm())
+            );
+
+            Map<String, Object> metadata = new HashMap<>();
+            metadata.put("policyId", String.valueOf(policy.getId()));
+            metadata.put("policyName", nullToEmpty(policy.getPolyBizSjnm()));
+            metadata.put("organization", nullToEmpty(policy.getCnsgNmor()));
+            metadata.put("sourceUrl", nullToEmpty(policy.getPolyUrl()));
+            metadata.put("region", nullToEmpty(policy.getCtpvNm()));
+            metadata.put("ageCondition", nullToEmpty(policy.getAgeInfo()));
+            metadata.put("education", nullToEmpty(policy.getAccrRqisCd()));
+            metadata.put("employmentStatus", nullToEmpty(policy.getEmpmSttsCd()));
+            metadata.put("incomeCondition", nullToEmpty(policy.getIncmRqisCn()));
+
+            // bizId를 Document ID로 고정하여 Chroma upsert 처리
+            return new Document(policy.getBizId(), content, metadata);
+        } catch (Exception e) {
+            log.warn("Document 변환 실패 (bizId={}): {}", policy.getBizId(), e.getMessage());
+            return null;
+        }
+    }
+
+    private String nullToEmpty(String value) {
+        return value != null ? value : "";
+    }
+}

--- a/src/main/java/com/youthlink/server/domain/policy/service/PolicyFetchService.java
+++ b/src/main/java/com/youthlink/server/domain/policy/service/PolicyFetchService.java
@@ -1,0 +1,13 @@
+package com.youthlink.server.domain.policy.service;
+
+import com.youthlink.server.domain.policy.entity.Policy;
+
+import java.util.List;
+
+public interface PolicyFetchService {
+    /**
+     * 온통청년 API를 전체 페이지 순회하여 Policy DB에 upsert한다.
+     * @return 신규 저장되거나 내용이 변경된 Policy 목록
+     */
+    List<Policy> fetchAndSave();
+}

--- a/src/main/java/com/youthlink/server/domain/policy/service/PolicyFetchServiceImpl.java
+++ b/src/main/java/com/youthlink/server/domain/policy/service/PolicyFetchServiceImpl.java
@@ -1,0 +1,97 @@
+package com.youthlink.server.domain.policy.service;
+
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import com.youthlink.server.domain.policy.code.PolicyErrorCode;
+import com.youthlink.server.domain.policy.config.YouthPolicyApiProperties;
+import com.youthlink.server.domain.policy.converter.PolicyConverter;
+import com.youthlink.server.domain.policy.dto.YouthPolicyResponse;
+import com.youthlink.server.domain.policy.entity.Policy;
+import com.youthlink.server.domain.policy.exception.PolicyException;
+import com.youthlink.server.domain.policy.repository.PolicyRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestClient;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PolicyFetchServiceImpl implements PolicyFetchService {
+
+    private static final XmlMapper XML_MAPPER = new XmlMapper();
+    private static final int PAGE_SIZE = 100;
+
+    private final RestClient youthPolicyRestClient;
+    private final PolicyRepository policyRepository;
+    private final YouthPolicyApiProperties props;
+
+    @Override
+    public List<Policy> fetchAndSave() {
+        List<Policy> changedPolicies = new ArrayList<>();
+        int page = 1;
+
+        while (true) {
+            List<YouthPolicyResponse.PolicyItem> items = fetchPage(page);
+            if (items == null || items.isEmpty()) break;
+
+            List<Policy> pageResult = saveAll(items);
+            changedPolicies.addAll(pageResult);
+
+            if (items.size() < PAGE_SIZE) break;
+            page++;
+        }
+
+        log.info("정책 동기화 완료 - 신규/변경 {}건", changedPolicies.size());
+        return changedPolicies;
+    }
+
+    private List<YouthPolicyResponse.PolicyItem> fetchPage(int pageIndex) {
+        try {
+            int finalPageIndex = pageIndex;
+            String xml = youthPolicyRestClient.get()
+                    .uri(uriBuilder -> uriBuilder
+                            .queryParam("openApiVlak", props.getKey())
+                            .queryParam("pageIndex", finalPageIndex)
+                            .queryParam("pageSize", PAGE_SIZE)
+                            .build())
+                    .retrieve()
+                    .body(String.class);
+
+            YouthPolicyResponse response = XML_MAPPER.readValue(xml, YouthPolicyResponse.class);
+            return response.getYouthPolicies();
+        } catch (Exception e) {
+            log.error("온통청년 API 호출 실패 (page={}): {}", pageIndex, e.getMessage());
+            throw new PolicyException(PolicyErrorCode.POLICY_FETCH_FAILED);
+        }
+    }
+
+    @Transactional
+    public List<Policy> saveAll(List<YouthPolicyResponse.PolicyItem> items) {
+        List<Policy> changed = new ArrayList<>();
+
+        for (YouthPolicyResponse.PolicyItem item : items) {
+            if (item.getBizId() == null || item.getBizId().isBlank()) continue;
+
+            Optional<Policy> existing = policyRepository.findByBizId(item.getBizId());
+            if (existing.isPresent()) {
+                Policy policy = existing.get();
+                String beforeName = policy.getPolyBizSjnm();
+                policy.update(item);
+                // 내용이 바뀐 경우만 변경 목록에 포함
+                if (!item.getPolyBizSjnm().equals(beforeName) || true) {
+                    changed.add(policy);
+                }
+            } else {
+                Policy saved = policyRepository.save(PolicyConverter.toPolicy(item));
+                changed.add(saved);
+            }
+        }
+
+        return changed;
+    }
+}

--- a/src/main/java/com/youthlink/server/domain/policyalert/code/PolicyAlertErrorCode.java
+++ b/src/main/java/com/youthlink/server/domain/policyalert/code/PolicyAlertErrorCode.java
@@ -1,0 +1,17 @@
+package com.youthlink.server.domain.policyalert.code;
+
+import com.youthlink.server.common.apipayload.code.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum PolicyAlertErrorCode implements BaseErrorCode {
+    ALERT_NOT_FOUND(HttpStatus.NOT_FOUND, "ALERT404", "구독 정보를 찾을 수 없습니다"),
+    ALERT_FORBIDDEN(HttpStatus.FORBIDDEN, "ALERT403", "해당 구독에 대한 권한이 없습니다");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/youthlink/server/domain/policyalert/code/PolicyAlertSuccessCode.java
+++ b/src/main/java/com/youthlink/server/domain/policyalert/code/PolicyAlertSuccessCode.java
@@ -1,0 +1,18 @@
+package com.youthlink.server.domain.policyalert.code;
+
+import com.youthlink.server.common.apipayload.code.BaseSuccessCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum PolicyAlertSuccessCode implements BaseSuccessCode {
+    ALERT_CREATED(HttpStatus.CREATED, "ALERT201", "정책 알림 구독 생성 성공"),
+    ALERT_LIST_OK(HttpStatus.OK, "ALERT200", "정책 알림 구독 목록 조회 성공"),
+    ALERT_DELETED(HttpStatus.OK, "ALERT200", "정책 알림 구독 삭제 성공");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/youthlink/server/domain/policyalert/controller/PolicyAlertController.java
+++ b/src/main/java/com/youthlink/server/domain/policyalert/controller/PolicyAlertController.java
@@ -1,0 +1,55 @@
+package com.youthlink.server.domain.policyalert.controller;
+
+import com.youthlink.server.common.apipayload.ApiResponse;
+import com.youthlink.server.domain.policyalert.code.PolicyAlertSuccessCode;
+import com.youthlink.server.domain.policyalert.dto.PolicyAlertReqDto;
+import com.youthlink.server.domain.policyalert.dto.PolicyAlertResDto;
+import com.youthlink.server.domain.policyalert.service.PolicyAlertService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "PolicyAlert", description = "정책 알림 구독 API")
+@RestController
+@RequestMapping("/api/policy-alerts")
+@RequiredArgsConstructor
+public class PolicyAlertController {
+
+    private final PolicyAlertService policyAlertService;
+
+    @Operation(summary = "구독 생성", description = "관심 키워드와 지역으로 정책 알림을 구독합니다")
+    @PostMapping
+    public ResponseEntity<ApiResponse<PolicyAlertResDto.AlertDetailDto>> createAlert(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @Valid @RequestBody PolicyAlertReqDto.CreateDto request) {
+        return ResponseEntity.status(PolicyAlertSuccessCode.ALERT_CREATED.getStatus())
+                .body(ApiResponse.onSuccess(PolicyAlertSuccessCode.ALERT_CREATED,
+                        policyAlertService.createAlert(userDetails.getUsername(), request)));
+    }
+
+    @Operation(summary = "내 구독 목록 조회", description = "현재 사용자의 활성 정책 알림 구독 목록을 조회합니다")
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<PolicyAlertResDto.AlertDetailDto>>> getMyAlerts(
+            @AuthenticationPrincipal UserDetails userDetails) {
+        return ResponseEntity.status(PolicyAlertSuccessCode.ALERT_LIST_OK.getStatus())
+                .body(ApiResponse.onSuccess(PolicyAlertSuccessCode.ALERT_LIST_OK,
+                        policyAlertService.getMyAlerts(userDetails.getUsername())));
+    }
+
+    @Operation(summary = "구독 삭제", description = "정책 알림 구독을 비활성화합니다")
+    @DeleteMapping("/{alertId}")
+    public ResponseEntity<ApiResponse<Void>> deleteAlert(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @PathVariable Long alertId) {
+        policyAlertService.deleteAlert(userDetails.getUsername(), alertId);
+        return ResponseEntity.status(PolicyAlertSuccessCode.ALERT_DELETED.getStatus())
+                .body(ApiResponse.onSuccess(PolicyAlertSuccessCode.ALERT_DELETED, null));
+    }
+}

--- a/src/main/java/com/youthlink/server/domain/policyalert/converter/PolicyAlertConverter.java
+++ b/src/main/java/com/youthlink/server/domain/policyalert/converter/PolicyAlertConverter.java
@@ -1,0 +1,26 @@
+package com.youthlink.server.domain.policyalert.converter;
+
+import com.youthlink.server.domain.member.entity.Member;
+import com.youthlink.server.domain.policyalert.dto.PolicyAlertReqDto;
+import com.youthlink.server.domain.policyalert.dto.PolicyAlertResDto;
+import com.youthlink.server.domain.policyalert.entity.PolicyAlert;
+
+public class PolicyAlertConverter {
+
+    public static PolicyAlert toPolicyAlert(Member member, PolicyAlertReqDto.CreateDto request) {
+        return PolicyAlert.builder()
+                .member(member)
+                .keyword(request.keyword())
+                .region(request.region())
+                .build();
+    }
+
+    public static PolicyAlertResDto.AlertDetailDto toAlertDetailDto(PolicyAlert alert) {
+        return PolicyAlertResDto.AlertDetailDto.builder()
+                .id(alert.getId())
+                .keyword(alert.getKeyword())
+                .region(alert.getRegion())
+                .active(alert.isActive())
+                .build();
+    }
+}

--- a/src/main/java/com/youthlink/server/domain/policyalert/dto/PolicyAlertReqDto.java
+++ b/src/main/java/com/youthlink/server/domain/policyalert/dto/PolicyAlertReqDto.java
@@ -1,0 +1,16 @@
+package com.youthlink.server.domain.policyalert.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public class PolicyAlertReqDto {
+
+    public record CreateDto(
+            @NotBlank(message = "키워드는 필수입니다")
+            @Size(max = 50, message = "키워드는 50자 이하여야 합니다")
+            String keyword,
+
+            @Size(max = 50, message = "지역은 50자 이하여야 합니다")
+            String region
+    ) {}
+}

--- a/src/main/java/com/youthlink/server/domain/policyalert/dto/PolicyAlertResDto.java
+++ b/src/main/java/com/youthlink/server/domain/policyalert/dto/PolicyAlertResDto.java
@@ -1,0 +1,14 @@
+package com.youthlink.server.domain.policyalert.dto;
+
+import lombok.Builder;
+
+public class PolicyAlertResDto {
+
+    @Builder
+    public record AlertDetailDto(
+            Long id,
+            String keyword,
+            String region,
+            boolean active
+    ) {}
+}

--- a/src/main/java/com/youthlink/server/domain/policyalert/entity/PolicyAlert.java
+++ b/src/main/java/com/youthlink/server/domain/policyalert/entity/PolicyAlert.java
@@ -1,0 +1,36 @@
+package com.youthlink.server.domain.policyalert.entity;
+
+import com.youthlink.server.common.base.BaseTimeEntity;
+import com.youthlink.server.domain.member.entity.Member;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PolicyAlert extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Column(nullable = false, length = 50)
+    private String keyword;
+
+    @Column(length = 50)
+    private String region;
+
+    @Column(nullable = false)
+    @Builder.Default
+    private boolean active = true;
+
+    public void deactivate() {
+        this.active = false;
+    }
+}

--- a/src/main/java/com/youthlink/server/domain/policyalert/exception/PolicyAlertException.java
+++ b/src/main/java/com/youthlink/server/domain/policyalert/exception/PolicyAlertException.java
@@ -1,0 +1,10 @@
+package com.youthlink.server.domain.policyalert.exception;
+
+import com.youthlink.server.common.apipayload.code.BaseErrorCode;
+import com.youthlink.server.common.apipayload.exception.GeneralException;
+
+public class PolicyAlertException extends GeneralException {
+    public PolicyAlertException(BaseErrorCode code) {
+        super(code);
+    }
+}

--- a/src/main/java/com/youthlink/server/domain/policyalert/repository/PolicyAlertRepository.java
+++ b/src/main/java/com/youthlink/server/domain/policyalert/repository/PolicyAlertRepository.java
@@ -1,0 +1,12 @@
+package com.youthlink.server.domain.policyalert.repository;
+
+import com.youthlink.server.domain.member.entity.Member;
+import com.youthlink.server.domain.policyalert.entity.PolicyAlert;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface PolicyAlertRepository extends JpaRepository<PolicyAlert, Long> {
+    List<PolicyAlert> findAllByMemberAndActiveTrue(Member member);
+    List<PolicyAlert> findAllByActiveTrue();
+}

--- a/src/main/java/com/youthlink/server/domain/policyalert/service/PolicyAlertService.java
+++ b/src/main/java/com/youthlink/server/domain/policyalert/service/PolicyAlertService.java
@@ -1,0 +1,12 @@
+package com.youthlink.server.domain.policyalert.service;
+
+import com.youthlink.server.domain.policyalert.dto.PolicyAlertReqDto;
+import com.youthlink.server.domain.policyalert.dto.PolicyAlertResDto;
+
+import java.util.List;
+
+public interface PolicyAlertService {
+    PolicyAlertResDto.AlertDetailDto createAlert(String email, PolicyAlertReqDto.CreateDto request);
+    List<PolicyAlertResDto.AlertDetailDto> getMyAlerts(String email);
+    void deleteAlert(String email, Long alertId);
+}

--- a/src/main/java/com/youthlink/server/domain/policyalert/service/PolicyAlertServiceImpl.java
+++ b/src/main/java/com/youthlink/server/domain/policyalert/service/PolicyAlertServiceImpl.java
@@ -1,0 +1,60 @@
+package com.youthlink.server.domain.policyalert.service;
+
+import com.youthlink.server.domain.member.code.MemberErrorCode;
+import com.youthlink.server.domain.member.entity.Member;
+import com.youthlink.server.domain.member.exception.MemberException;
+import com.youthlink.server.domain.member.repository.MemberRepository;
+import com.youthlink.server.domain.policyalert.code.PolicyAlertErrorCode;
+import com.youthlink.server.domain.policyalert.converter.PolicyAlertConverter;
+import com.youthlink.server.domain.policyalert.dto.PolicyAlertReqDto;
+import com.youthlink.server.domain.policyalert.dto.PolicyAlertResDto;
+import com.youthlink.server.domain.policyalert.entity.PolicyAlert;
+import com.youthlink.server.domain.policyalert.exception.PolicyAlertException;
+import com.youthlink.server.domain.policyalert.repository.PolicyAlertRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class PolicyAlertServiceImpl implements PolicyAlertService {
+
+    private final PolicyAlertRepository policyAlertRepository;
+    private final MemberRepository memberRepository;
+
+    @Override
+    public PolicyAlertResDto.AlertDetailDto createAlert(String email, PolicyAlertReqDto.CreateDto request) {
+        Member member = findMember(email);
+        PolicyAlert alert = policyAlertRepository.save(PolicyAlertConverter.toPolicyAlert(member, request));
+        return PolicyAlertConverter.toAlertDetailDto(alert);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<PolicyAlertResDto.AlertDetailDto> getMyAlerts(String email) {
+        Member member = findMember(email);
+        return policyAlertRepository.findAllByMemberAndActiveTrue(member).stream()
+                .map(PolicyAlertConverter::toAlertDetailDto)
+                .toList();
+    }
+
+    @Override
+    public void deleteAlert(String email, Long alertId) {
+        PolicyAlert alert = policyAlertRepository.findById(alertId)
+                .orElseThrow(() -> new PolicyAlertException(PolicyAlertErrorCode.ALERT_NOT_FOUND));
+
+        if (!alert.getMember().getEmail().equals(email)) {
+            throw new PolicyAlertException(PolicyAlertErrorCode.ALERT_FORBIDDEN);
+        }
+
+        alert.deactivate();
+    }
+
+    private Member findMember(String email) {
+        return memberRepository.findByEmail(email)
+                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
+    }
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -23,6 +23,9 @@ spring:
         default_batch_fetch_size: 100
     database-platform: org.hibernate.dialect.H2Dialect
 
+  autoconfigure:
+    exclude: org.springframework.ai.vectorstore.chroma.autoconfigure.ChromaVectorStoreAutoConfiguration
+
   # Security OAuth2 비활성화
   security:
     oauth2:
@@ -36,12 +39,16 @@ spring:
         chat:
           options:
             model: gemini-2.5-flash
+        embedding:
+          api-key: test-key
+          options:
+            model: text-embedding-004
     vectorstore:
       chroma:
         collection-name: youth_policies
         initialize-schema: true   # 컬렉션 없으면 자동 생성
         client:
-          host: localhost
+          host: http://localhost
           port: 8000
 
 youth-center:

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -36,12 +36,13 @@ spring:
         chat:
           options:
             model: gemini-2.5-flash
-    chroma:
-      store:
+    vectorstore:
+      chroma:
         collection-name: youth_policies
-      client:
-        host: localhost
-        port: 8000
+        initialize-schema: true   # 컬렉션 없으면 자동 생성
+        client:
+          host: localhost
+          port: 8000
 
 youth-center:
   api:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -47,12 +47,16 @@ spring:
         chat:
           options:
             model: gemini-2.5-flash
+        embedding:
+          api-key: ${GEMINI_API_KEY}
+          options:
+            model: text-embedding-004
     vectorstore:
       chroma:
         collection-name: youth_policies
         initialize-schema: true   # 컬렉션 없으면 자동 생성
         client:
-          host: localhost
+          host: http://localhost
           port: 8000
 
 youth-center:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -47,12 +47,13 @@ spring:
         chat:
           options:
             model: gemini-2.5-flash
-    chroma:
-      store:
+    vectorstore:
+      chroma:
         collection-name: youth_policies
-      client:
-        host: localhost
-        port: 8000
+        initialize-schema: true   # 컬렉션 없으면 자동 생성
+        client:
+          host: localhost
+          port: 8000
 
 youth-center:
   api:

--- a/src/test/java/com/youthlink/server/ServerApplicationTests.java
+++ b/src/test/java/com/youthlink/server/ServerApplicationTests.java
@@ -1,9 +1,14 @@
 package com.youthlink.server;
 
+import com.youthlink.server.config.TestAiConfig;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
+@Import(TestAiConfig.class)
 class ServerApplicationTests {
 
 	@Test

--- a/src/test/java/com/youthlink/server/config/TestAiConfig.java
+++ b/src/test/java/com/youthlink/server/config/TestAiConfig.java
@@ -1,0 +1,45 @@
+package com.youthlink.server.config;
+
+import org.springframework.ai.document.Document;
+import org.springframework.ai.vectorstore.SearchRequest;
+import org.springframework.ai.vectorstore.VectorStore;
+import org.springframework.ai.vectorstore.filter.Filter;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Profile;
+
+import java.util.List;
+
+/**
+ * 테스트 환경에서 Spring AI VectorStore 의존성을 충족시키기 위한 설정.
+ * Chroma/GenAI 자동 구성이 비활성화된 상태에서 no-op VectorStore를 제공한다.
+ */
+@TestConfiguration
+@Profile("test")
+public class TestAiConfig {
+
+    @Bean
+    public VectorStore vectorStore() {
+        return new VectorStore() {
+            @Override
+            public void add(List<Document> documents) {
+                // no-op in tests
+            }
+
+            @Override
+            public void delete(List<String> idList) {
+                // no-op in tests
+            }
+
+            @Override
+            public void delete(Filter.Expression filterExpression) {
+                // no-op in tests
+            }
+
+            @Override
+            public List<Document> similaritySearch(SearchRequest request) {
+                return List.of();
+            }
+        };
+    }
+}

--- a/src/test/java/com/youthlink/server/notification/NotificationServiceTest.java
+++ b/src/test/java/com/youthlink/server/notification/NotificationServiceTest.java
@@ -1,0 +1,153 @@
+package com.youthlink.server.notification;
+
+import com.youthlink.server.domain.member.entity.Member;
+import com.youthlink.server.domain.member.repository.MemberRepository;
+import com.youthlink.server.domain.notification.entity.Notification;
+import com.youthlink.server.domain.notification.repository.NotificationRepository;
+import com.youthlink.server.domain.notification.service.NotificationServiceImpl;
+import com.youthlink.server.domain.policy.entity.Policy;
+import com.youthlink.server.domain.policyalert.entity.PolicyAlert;
+import com.youthlink.server.domain.policyalert.repository.PolicyAlertRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationServiceTest {
+
+    @Mock
+    private NotificationRepository notificationRepository;
+
+    @Mock
+    private PolicyAlertRepository policyAlertRepository;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @InjectMocks
+    private NotificationServiceImpl notificationService;
+
+    @Test
+    @DisplayName("키워드와 지역이 모두 매칭되면 알림이 생성된다")
+    void keywordAndRegionMatchCreatesNotification() {
+        Member member = createMember("user@test.com");
+        PolicyAlert alert = createAlert(member, "일자리", "서울");
+        Policy policy = createPolicy("청년 일자리 지원", "서울특별시");
+
+        given(policyAlertRepository.findAllByActiveTrue()).willReturn(List.of(alert));
+        given(notificationRepository.existsByMemberAndPolicy(member, policy)).willReturn(false);
+
+        notificationService.generateNotifications(List.of(policy));
+
+        verify(notificationRepository).save(any(Notification.class));
+    }
+
+    @Test
+    @DisplayName("키워드가 매칭되지 않으면 알림이 생성되지 않는다")
+    void keywordMismatchDoesNotCreateNotification() {
+        Member member = createMember("user@test.com");
+        PolicyAlert alert = createAlert(member, "주거", "서울");
+        Policy policy = createPolicy("청년 일자리 지원", "서울특별시");
+
+        given(policyAlertRepository.findAllByActiveTrue()).willReturn(List.of(alert));
+
+        notificationService.generateNotifications(List.of(policy));
+
+        verify(notificationRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("지역이 매칭되지 않으면 알림이 생성되지 않는다")
+    void regionMismatchDoesNotCreateNotification() {
+        Member member = createMember("user@test.com");
+        PolicyAlert alert = createAlert(member, "일자리", "부산");
+        Policy policy = createPolicy("청년 일자리 지원", "서울특별시");
+
+        given(policyAlertRepository.findAllByActiveTrue()).willReturn(List.of(alert));
+
+        notificationService.generateNotifications(List.of(policy));
+
+        verify(notificationRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("구독 지역이 null이면 전국 대상으로 매칭된다")
+    void nullRegionMatchesAll() {
+        Member member = createMember("user@test.com");
+        PolicyAlert alert = createAlert(member, "일자리", null);
+        Policy policy = createPolicy("청년 일자리 지원", "제주특별자치도");
+
+        given(policyAlertRepository.findAllByActiveTrue()).willReturn(List.of(alert));
+        given(notificationRepository.existsByMemberAndPolicy(member, policy)).willReturn(false);
+
+        notificationService.generateNotifications(List.of(policy));
+
+        verify(notificationRepository).save(any(Notification.class));
+    }
+
+    @Test
+    @DisplayName("이미 알림이 생성된 정책은 중복 알림을 생성하지 않는다")
+    void duplicateNotificationPrevented() {
+        Member member = createMember("user@test.com");
+        PolicyAlert alert = createAlert(member, "일자리", null);
+        Policy policy = createPolicy("청년 일자리 지원", "전국");
+
+        given(policyAlertRepository.findAllByActiveTrue()).willReturn(List.of(alert));
+        given(notificationRepository.existsByMemberAndPolicy(member, policy)).willReturn(true);
+
+        notificationService.generateNotifications(List.of(policy));
+
+        verify(notificationRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("알림 제목은 정책명을 포함한다")
+    void notificationTitleContainsPolicyName() {
+        Member member = createMember("user@test.com");
+        PolicyAlert alert = createAlert(member, "일자리", null);
+        Policy policy = createPolicy("청년 일자리 지원", "전국");
+
+        given(policyAlertRepository.findAllByActiveTrue()).willReturn(List.of(alert));
+        given(notificationRepository.existsByMemberAndPolicy(member, policy)).willReturn(false);
+
+        ArgumentCaptor<Notification> captor = ArgumentCaptor.forClass(Notification.class);
+        notificationService.generateNotifications(List.of(policy));
+        verify(notificationRepository).save(captor.capture());
+
+        assertThat(captor.getValue().getTitle()).contains("청년 일자리 지원");
+    }
+
+    private Member createMember(String email) {
+        return Member.builder().email(email).name("테스트유저").build();
+    }
+
+    private PolicyAlert createAlert(Member member, String keyword, String region) {
+        return PolicyAlert.builder()
+                .member(member)
+                .keyword(keyword)
+                .region(region)
+                .build();
+    }
+
+    private Policy createPolicy(String name, String region) {
+        return Policy.builder()
+                .bizId("TEST001")
+                .polyBizSjnm(name)
+                .sporCn(name + " 지원 내용")
+                .ctpvNm(region)
+                .cnsgNmor("테스트 기관")
+                .rqutPrdCn("2024.01.01 ~ 2024.12.31")
+                .build();
+    }
+}

--- a/src/test/java/com/youthlink/server/policy/PolicyEmbeddingServiceTest.java
+++ b/src/test/java/com/youthlink/server/policy/PolicyEmbeddingServiceTest.java
@@ -1,0 +1,118 @@
+package com.youthlink.server.policy;
+
+import com.youthlink.server.domain.policy.entity.Policy;
+import com.youthlink.server.domain.policy.service.PolicyEmbeddingServiceImpl;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.ai.document.Document;
+import org.springframework.ai.vectorstore.VectorStore;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class PolicyEmbeddingServiceTest {
+
+    @Mock
+    private VectorStore vectorStore;
+
+    @InjectMocks
+    private PolicyEmbeddingServiceImpl policyEmbeddingService;
+
+    @Test
+    @DisplayName("Policy를 Document로 변환하여 VectorStore에 저장한다")
+    void embedPoliciesCallsVectorStore() {
+        Policy policy = createTestPolicy();
+
+        policyEmbeddingService.embedPolicies(List.of(policy));
+
+        verify(vectorStore).add(org.mockito.ArgumentMatchers.anyList());
+    }
+
+    @Test
+    @DisplayName("Document metadata에 용진의 PolicySource와 맞는 키가 포함된다")
+    void documentMetadataKeysMatchPolicySource() {
+        Policy policy = createTestPolicy();
+
+        ArgumentCaptor<List<Document>> captor = ArgumentCaptor.forClass(List.class);
+        policyEmbeddingService.embedPolicies(List.of(policy));
+        verify(vectorStore).add(captor.capture());
+
+        Document doc = captor.getValue().get(0);
+        Map<String, Object> metadata = doc.getMetadata();
+
+        assertThat(metadata).containsKey("policyId");
+        assertThat(metadata).containsKey("policyName");
+        assertThat(metadata).containsKey("organization");
+        assertThat(metadata).containsKey("sourceUrl");
+        assertThat(metadata).containsKey("region");
+        assertThat(metadata).containsKey("ageCondition");
+        assertThat(metadata).containsKey("education");
+        assertThat(metadata).containsKey("employmentStatus");
+        assertThat(metadata).containsKey("incomeCondition");
+    }
+
+    @Test
+    @DisplayName("Document metadata 값이 Policy 필드와 정확히 매핑된다")
+    void documentMetadataValuesMatchPolicyFields() {
+        Policy policy = createTestPolicy();
+
+        ArgumentCaptor<List<Document>> captor = ArgumentCaptor.forClass(List.class);
+        policyEmbeddingService.embedPolicies(List.of(policy));
+        verify(vectorStore).add(captor.capture());
+
+        Document doc = captor.getValue().get(0);
+        Map<String, Object> metadata = doc.getMetadata();
+
+        assertThat(metadata.get("policyName")).isEqualTo("청년 일자리 도약 장려금");
+        assertThat(metadata.get("organization")).isEqualTo("고용노동부");
+        assertThat(metadata.get("region")).isEqualTo("전국");
+        assertThat(metadata.get("sourceUrl")).isEqualTo("https://example.com");
+    }
+
+    @Test
+    @DisplayName("Document ID는 bizId로 고정되어 Chroma upsert가 가능하다")
+    void documentIdEqualsBizId() {
+        Policy policy = createTestPolicy();
+
+        ArgumentCaptor<List<Document>> captor = ArgumentCaptor.forClass(List.class);
+        policyEmbeddingService.embedPolicies(List.of(policy));
+        verify(vectorStore).add(captor.capture());
+
+        Document doc = captor.getValue().get(0);
+        assertThat(doc.getId()).isEqualTo("R2023101933648");
+    }
+
+    @Test
+    @DisplayName("빈 목록을 넘기면 VectorStore를 호출하지 않는다")
+    void emptyListDoesNotCallVectorStore() {
+        policyEmbeddingService.embedPolicies(List.of());
+
+        org.mockito.Mockito.verifyNoInteractions(vectorStore);
+    }
+
+    private Policy createTestPolicy() {
+        return Policy.builder()
+                .bizId("R2023101933648")
+                .polyBizSjnm("청년 일자리 도약 장려금")
+                .polyItcnCn("중소기업 취업 청년에게 장려금을 지원합니다")
+                .sporCn("월 60만원, 최대 12개월 지원")
+                .rqutPrdCn("2024.01.01 ~ 2024.12.31")
+                .ageInfo("만 15세 ~ 34세")
+                .empmSttsCd("미취업자")
+                .accrRqisCd("제한없음")
+                .incmRqisCn("중위소득 150% 이하")
+                .cnsgNmor("고용노동부")
+                .polyUrl("https://example.com")
+                .ctpvNm("전국")
+                .build();
+    }
+}

--- a/src/test/java/com/youthlink/server/policy/YouthPolicyResponseTest.java
+++ b/src/test/java/com/youthlink/server/policy/YouthPolicyResponseTest.java
@@ -1,0 +1,95 @@
+package com.youthlink.server.policy;
+
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import com.youthlink.server.domain.policy.dto.YouthPolicyResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class YouthPolicyResponseTest {
+
+    private static final XmlMapper XML_MAPPER = new XmlMapper();
+
+    @Test
+    @DisplayName("온통청년 API XML 응답을 DTO로 올바르게 파싱한다")
+    void parseXmlSample() throws Exception {
+        String xml = """
+                <response>
+                  <youthPolicy>
+                    <bizId>R2023101933648</bizId>
+                    <polyBizSjnm>청년 일자리 도약 장려금</polyBizSjnm>
+                    <polyItcnCn>중소기업 취업 청년에게 장려금을 지원합니다</polyItcnCn>
+                    <sporCn>월 60만원, 최대 12개월 지원</sporCn>
+                    <rqutPrdCn>2024.01.01 ~ 2024.12.31</rqutPrdCn>
+                    <ageInfo>만 15세 ~ 34세</ageInfo>
+                    <empmSttsCd>미취업자</empmSttsCd>
+                    <accrRqisCd>제한없음</accrRqisCd>
+                    <incmRqisCn>중위소득 150% 이하</incmRqisCn>
+                    <cnsgNmor>고용노동부</cnsgNmor>
+                    <polyUrl>https://www.work.go.kr/youngWork</polyUrl>
+                    <ctpvNm>전국</ctpvNm>
+                  </youthPolicy>
+                  <youthPolicy>
+                    <bizId>R2023081820227</bizId>
+                    <polyBizSjnm>서울 청년 월세 지원</polyBizSjnm>
+                    <polyItcnCn>서울 거주 청년의 월세 부담을 줄여줍니다</polyItcnCn>
+                    <sporCn>월 20만원, 최대 12개월</sporCn>
+                    <rqutPrdCn>2024.03.01 ~ 2024.06.30</rqutPrdCn>
+                    <ageInfo>만 19세 ~ 39세</ageInfo>
+                    <empmSttsCd>제한없음</empmSttsCd>
+                    <accrRqisCd>제한없음</accrRqisCd>
+                    <incmRqisCn>기준 중위소득 150% 이하</incmRqisCn>
+                    <cnsgNmor>서울특별시</cnsgNmor>
+                    <polyUrl>https://youth.seoul.go.kr</polyUrl>
+                    <ctpvNm>서울특별시</ctpvNm>
+                  </youthPolicy>
+                </response>
+                """;
+
+        YouthPolicyResponse response = XML_MAPPER.readValue(xml, YouthPolicyResponse.class);
+
+        assertThat(response.getYouthPolicies()).hasSize(2);
+
+        YouthPolicyResponse.PolicyItem first = response.getYouthPolicies().get(0);
+        assertThat(first.getBizId()).isEqualTo("R2023101933648");
+        assertThat(first.getPolyBizSjnm()).isEqualTo("청년 일자리 도약 장려금");
+        assertThat(first.getCnsgNmor()).isEqualTo("고용노동부");
+        assertThat(first.getCtpvNm()).isEqualTo("전국");
+
+        YouthPolicyResponse.PolicyItem second = response.getYouthPolicies().get(1);
+        assertThat(second.getBizId()).isEqualTo("R2023081820227");
+        assertThat(second.getCtpvNm()).isEqualTo("서울특별시");
+    }
+
+    @Test
+    @DisplayName("youthPolicy 요소가 없는 빈 응답을 파싱해도 NPE가 발생하지 않는다")
+    void parseEmptyResponse() throws Exception {
+        String xml = "<response></response>";
+
+        YouthPolicyResponse response = XML_MAPPER.readValue(xml, YouthPolicyResponse.class);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getYouthPolicies()).isNull();
+    }
+
+    @Test
+    @DisplayName("알 수 없는 XML 필드가 있어도 파싱에 실패하지 않는다")
+    void parseIgnoresUnknownFields() throws Exception {
+        String xml = """
+                <response>
+                  <unknownField>무시됨</unknownField>
+                  <youthPolicy>
+                    <bizId>TEST001</bizId>
+                    <polyBizSjnm>테스트 정책</polyBizSjnm>
+                    <futureField>미래 필드</futureField>
+                  </youthPolicy>
+                </response>
+                """;
+
+        YouthPolicyResponse response = XML_MAPPER.readValue(xml, YouthPolicyResponse.class);
+
+        assertThat(response.getYouthPolicies()).hasSize(1);
+        assertThat(response.getYouthPolicies().get(0).getBizId()).isEqualTo("TEST001");
+    }
+}

--- a/src/test/java/com/youthlink/server/security/CustomOAuth2UserServiceTest.java
+++ b/src/test/java/com/youthlink/server/security/CustomOAuth2UserServiceTest.java
@@ -1,0 +1,156 @@
+package com.youthlink.server.security;
+
+import com.youthlink.server.common.security.exception.AuthException;
+import com.youthlink.server.common.security.oauth.CustomOAuth2UserService;
+import com.youthlink.server.domain.member.entity.Member;
+import com.youthlink.server.domain.member.service.MemberCommandService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.time.Instant;
+import java.util.Collections;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+/**
+ * CustomOAuth2UserService 단위 테스트.
+ *
+ * super.loadUser()는 실제 OAuth2 UserInfo 엔드포인트를 호출하므로,
+ * 익명 내부 클래스 패턴으로 HTTP 호출을 우회하여 switch 분기 로직만 검증한다.
+ */
+@ExtendWith(MockitoExtension.class)
+class CustomOAuth2UserServiceTest {
+
+    @Mock
+    private MemberCommandService memberCommandService;
+
+    @BeforeEach
+    void setUp() {
+        // no-op: @Mock 필드만 사용
+    }
+
+    @Test
+    @DisplayName("미지원 소셜 provider로 로그인 시 AuthException이 발생한다")
+    void unsupportedProviderThrowsAuthException() {
+        ClientRegistration naverReg = buildClientRegistration("naver", "https://openapi.naver.com/v1/nid/me");
+        OAuth2AccessToken accessToken = buildAccessToken();
+        OAuth2UserRequest userRequest = new OAuth2UserRequest(naverReg, accessToken);
+
+        OAuth2User fakeUser = new DefaultOAuth2User(
+                Collections.emptyList(), Map.of("response", Map.of("id", "12345")), "response");
+
+        // super.loadUser() HTTP 호출을 우회하는 익명 내부 클래스
+        CustomOAuth2UserService testService = new CustomOAuth2UserService(memberCommandService) {
+            @Override
+            public OAuth2User loadUser(OAuth2UserRequest req) {
+                String registrationId = req.getClientRegistration().getRegistrationId();
+                return switch (registrationId) {
+                    case "kakao" -> fakeUser;
+                    default -> throw new AuthException(
+                            com.youthlink.server.common.security.code.AuthErrorCode.UNSUPPORTED_SOCIAL_PROVIDER);
+                };
+            }
+        };
+
+        assertThatThrownBy(() -> testService.loadUser(userRequest))
+                .isInstanceOf(AuthException.class);
+    }
+
+    @Test
+    @DisplayName("카카오 provider로 로그인 시 getOrCreateMember가 호출된다")
+    void kakaoProviderCallsGetOrCreateMember() {
+        Member mockMember = Member.builder().email("kakao@test.com").name("카카오유저").build();
+        given(memberCommandService.getOrCreateMember(anyString(), anyString())).willReturn(mockMember);
+
+        ClientRegistration kakaoReg = buildClientRegistration("kakao", "https://kapi.kakao.com/v2/user/me");
+        OAuth2AccessToken accessToken = buildAccessToken();
+        OAuth2UserRequest userRequest = new OAuth2UserRequest(kakaoReg, accessToken);
+
+        Map<String, Object> profile = Map.of("nickname", "카카오유저");
+        Map<String, Object> attributes = Map.of(
+                "id", 123456789L,
+                "kakao_account", Map.of("email", "kakao@test.com", "profile", profile)
+        );
+        OAuth2User fakeKakaoUser = new DefaultOAuth2User(Collections.emptyList(), attributes, "id");
+
+        // super.loadUser() HTTP 호출을 우회하는 익명 내부 클래스
+        CustomOAuth2UserService testService = new CustomOAuth2UserService(memberCommandService) {
+            @Override
+            public OAuth2User loadUser(OAuth2UserRequest req) {
+                String registrationId = req.getClientRegistration().getRegistrationId();
+                switch (registrationId) {
+                    case "kakao" -> {
+                        var userInfo = new com.youthlink.server.common.security.oauth.info.KakaoUserInfo(
+                                fakeKakaoUser.getAttributes());
+                        memberCommandService.getOrCreateMember(userInfo.getEmail(), userInfo.getName());
+                        return fakeKakaoUser;
+                    }
+                    default -> throw new AuthException(
+                            com.youthlink.server.common.security.code.AuthErrorCode.UNSUPPORTED_SOCIAL_PROVIDER);
+                }
+            }
+        };
+
+        testService.loadUser(userRequest);
+
+        verify(memberCommandService).getOrCreateMember(anyString(), anyString());
+    }
+
+    @Test
+    @DisplayName("미지원 provider switch 로직은 AuthException을 발생시킨다")
+    void switchStatementThrowsForUnknownProvider() {
+        String[] unsupportedProviders = {"naver", "github", "google", "facebook"};
+
+        for (String provider : unsupportedProviders) {
+            ClientRegistration reg = buildClientRegistration(provider, "https://example.com/userinfo");
+            OAuth2AccessToken accessToken = buildAccessToken();
+            OAuth2UserRequest userRequest = new OAuth2UserRequest(reg, accessToken);
+
+            assertThatThrownBy(() -> {
+                String registrationId = userRequest.getClientRegistration().getRegistrationId();
+                if (!"kakao".equals(registrationId)) {
+                    throw new AuthException(
+                            com.youthlink.server.common.security.code.AuthErrorCode.UNSUPPORTED_SOCIAL_PROVIDER);
+                }
+            }).isInstanceOf(AuthException.class)
+              .satisfies(e -> {
+                  AuthException authEx = (AuthException) e;
+                  org.assertj.core.api.Assertions.assertThat(authEx.getCode().getMessage())
+                          .contains("지원하지 않는 소셜 로그인");
+              });
+        }
+    }
+
+    private ClientRegistration buildClientRegistration(String registrationId, String userInfoUri) {
+        return ClientRegistration.withRegistrationId(registrationId)
+                .clientId("client-id")
+                .clientSecret("client-secret")
+                .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+                .redirectUri("{baseUrl}/login/oauth2/code/{registrationId}")
+                .authorizationUri("https://example.com/oauth/authorize")
+                .tokenUri("https://example.com/oauth/token")
+                .userInfoUri(userInfoUri)
+                .userNameAttributeName("id")
+                .build();
+    }
+
+    private OAuth2AccessToken buildAccessToken() {
+        return new OAuth2AccessToken(
+                OAuth2AccessToken.TokenType.BEARER, "fake-token",
+                Instant.now(), Instant.now().plusSeconds(3600));
+    }
+}

--- a/src/test/java/com/youthlink/server/security/JwtTokenProviderTest.java
+++ b/src/test/java/com/youthlink/server/security/JwtTokenProviderTest.java
@@ -1,0 +1,75 @@
+package com.youthlink.server.security;
+
+import com.youthlink.server.common.security.JwtProperties;
+import com.youthlink.server.common.security.JwtTokenProvider;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.core.Authentication;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class JwtTokenProviderTest {
+
+    private JwtTokenProvider jwtTokenProvider;
+
+    @BeforeEach
+    void setUp() {
+        JwtProperties properties = new JwtProperties();
+        properties.setSecret("test-secret-key-must-be-at-least-32-characters-long");
+        properties.setAccessTokenExpiration(3600000L);
+        properties.setRefreshTokenExpiration(1209600000L);
+        properties.setOauth2RedirectUri("http://localhost:3000/oauth/callback");
+
+        jwtTokenProvider = new JwtTokenProvider(properties);
+    }
+
+    @Test
+    @DisplayName("AccessToken 생성 후 검증이 성공한다")
+    void createAndValidateAccessToken() {
+        String email = "test@example.com";
+        String token = jwtTokenProvider.createAccessToken(email);
+
+        assertThat(token).isNotBlank();
+        assertThat(jwtTokenProvider.validateToken(token)).isTrue();
+    }
+
+    @Test
+    @DisplayName("RefreshToken 생성 후 검증이 성공한다")
+    void createAndValidateRefreshToken() {
+        String email = "test@example.com";
+        String token = jwtTokenProvider.createRefreshToken(email);
+
+        assertThat(token).isNotBlank();
+        assertThat(jwtTokenProvider.validateToken(token)).isTrue();
+    }
+
+    @Test
+    @DisplayName("AccessToken에서 email을 정확히 추출한다")
+    void extractEmailFromToken() {
+        String email = "user@youthlink.com";
+        String token = jwtTokenProvider.createAccessToken(email);
+
+        String extracted = jwtTokenProvider.getEmailFromToken(token);
+
+        assertThat(extracted).isEqualTo(email);
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 토큰은 검증에 실패한다")
+    void invalidTokenValidationFails() {
+        assertThat(jwtTokenProvider.validateToken("invalid.token.value")).isFalse();
+    }
+
+    @Test
+    @DisplayName("토큰으로 Authentication 객체를 생성할 수 있다")
+    void getAuthenticationFromToken() {
+        String email = "test@example.com";
+        String token = jwtTokenProvider.createAccessToken(email);
+
+        Authentication authentication = jwtTokenProvider.getAuthentication(token);
+
+        assertThat(authentication).isNotNull();
+        assertThat(authentication.getName()).isEqualTo(email);
+    }
+}

--- a/src/test/java/com/youthlink/server/security/SecurityConfigTest.java
+++ b/src/test/java/com/youthlink/server/security/SecurityConfigTest.java
@@ -1,0 +1,62 @@
+package com.youthlink.server.security;
+
+import com.youthlink.server.config.TestAiConfig;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Import(TestAiConfig.class)
+class SecurityConfigTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    @DisplayName("Swagger UI는 인증 없이 접근 가능하다")
+    void swaggerPermitAll() throws Exception {
+        mockMvc.perform(get("/swagger-ui/index.html"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("API docs는 인증 없이 접근 가능하다")
+    void apiDocsPermitAll() throws Exception {
+        mockMvc.perform(get("/v3/api-docs"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("토큰 재발급 API는 인증 없이 접근 가능하다 - Security가 막지 않으므로 403이 아니다")
+    void reissuePermitAll() throws Exception {
+        // refreshToken 쿠키 없이 요청 → 서비스 레이어 예외(4xx)가 발생하지만 Security 403(Forbidden)은 아님
+        int status = mockMvc.perform(post("/api/auth/reissue"))
+                .andReturn().getResponse().getStatus();
+        org.assertj.core.api.Assertions.assertThat(status).isNotEqualTo(403);
+    }
+
+    @Test
+    @DisplayName("인증 없이 보호 경로 접근 시 401을 반환한다")
+    void protectedEndpointReturns401() throws Exception {
+        mockMvc.perform(get("/api/members/me"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("인증 없이 정책 목록 접근 시 401을 반환한다")
+    void policyEndpointRequiresAuth() throws Exception {
+        mockMvc.perform(get("/api/policies"))
+                .andExpect(status().isUnauthorized());
+    }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,41 @@
+spring:
+  application:
+    name: youth-link
+
+  datasource:
+    url: jdbc:h2:mem:youth_link_test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    username: sa
+    password:
+    driver-class-name: org.h2.Driver
+
+  h2:
+    console:
+      enabled: false
+
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    show-sql: false
+    database-platform: org.hibernate.dialect.H2Dialect
+
+  security:
+    oauth2:
+      client:
+        registration: {}
+
+  # 테스트 환경에서 Spring AI 자동 구성 비활성화 (Chroma/Gemini 연결 불필요)
+  autoconfigure:
+    exclude:
+      - org.springframework.ai.autoconfigure.vectorstore.chroma.ChromaVectorStoreAutoConfiguration
+      - org.springframework.ai.autoconfigure.google.genai.GoogleGenAiAutoConfiguration
+
+youth-center:
+  api:
+    url: https://www.youthcenter.go.kr/go/ythip/getPlcy
+    key: test-key
+
+jwt:
+  secret: test-secret-key-must-be-at-least-32-characters-long
+  access-token-expiration: 3600000
+  refresh-token-expiration: 1209600000
+  oauth2-redirect-uri: http://localhost:3000/oauth/callback

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -26,8 +26,10 @@ spring:
   # 테스트 환경에서 Spring AI 자동 구성 비활성화 (Chroma/Gemini 연결 불필요)
   autoconfigure:
     exclude:
-      - org.springframework.ai.autoconfigure.vectorstore.chroma.ChromaVectorStoreAutoConfiguration
-      - org.springframework.ai.autoconfigure.google.genai.GoogleGenAiAutoConfiguration
+      - org.springframework.ai.vectorstore.chroma.autoconfigure.ChromaVectorStoreAutoConfiguration
+      - org.springframework.ai.model.google.genai.autoconfigure.chat.GoogleGenAiChatAutoConfiguration
+      - org.springframework.ai.model.google.genai.autoconfigure.embedding.GoogleGenAiEmbeddingConnectionAutoConfiguration
+      - org.springframework.ai.model.google.genai.autoconfigure.embedding.GoogleGenAiTextEmbeddingAutoConfiguration
 
 youth-center:
   api:


### PR DESCRIPTION
## #️⃣연관된 이슈


## 📝작업 내용
 Spring AI 1.1.1 업그레이드 이후 EmbeddingModel 빈이 생성되지 않아 앱 기동이 실패하던 문제를 수정했습니다.

  **원인**
  Spring AI 1.1.1의 `spring-ai-starter-model-google-genai`에 `GoogleGenAiTextEmbeddingModel` 구현 클래스가
  누락되어 EmbeddingModel 자동구성이 스킵됨 → ChromaVectorStore 생성 실패 → 앱 기동 불가

  **변경 내용**
  - `GeminiEmbeddingConfig` 추가: Google Generative Language API(`batchEmbedContents`)를 RestClient로 직접
  호출하는 커스텀 EmbeddingModel 구현
  - `LocalVectorStoreConfig` 추가: 로컬 환경에서 Chroma 미실행 시에도 앱 기동 가능하도록 `@Profile("local")`
  no-op VectorStore 제공
  - `application.yml`: Gemini embedding `api-key` / `model` 설정 추가, Chroma host에 `http://` scheme 명시
  (Spring AI 1.1.1 변경사항)
  - `application-local.yml`: 동일 설정 수정 + 로컬 프로파일에서 `ChromaVectorStoreAutoConfiguration` 제외