### PR TITLE
[FEAT] 회원 프로필 설정 기능 및 Region 도메인 추가

### DIFF
--- a/src/main/java/com/youthlink/server/common/security/CurrentMemberProvider.java
+++ b/src/main/java/com/youthlink/server/common/security/CurrentMemberProvider.java
@@ -1,0 +1,38 @@
+package com.youthlink.server.common.security;
+
+import com.youthlink.server.common.security.code.AuthErrorCode;
+import com.youthlink.server.common.security.exception.AuthException;
+import com.youthlink.server.domain.member.code.MemberErrorCode;
+import com.youthlink.server.domain.member.entity.Member;
+import com.youthlink.server.domain.member.exception.MemberException;
+import com.youthlink.server.domain.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CurrentMemberProvider {
+
+    private final MemberRepository memberRepository;
+
+    public Member getCurrentMember() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !authentication.isAuthenticated()) {
+            throw new AuthException(AuthErrorCode.UNAUTHORIZED);
+        }
+
+        String email = authentication.getName();
+        if (email == null || email.isBlank() || "anonymousUser".equals(email)) {
+            throw new AuthException(AuthErrorCode.UNAUTHORIZED);
+        }
+
+        return memberRepository.findByEmail(email)
+                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
+    }
+
+    public Long getCurrentMemberId() {
+        return getCurrentMember().getId();
+    }
+}

--- a/src/main/java/com/youthlink/server/common/security/oauth/handler/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/youthlink/server/common/security/oauth/handler/OAuth2AuthenticationSuccessHandler.java
@@ -2,6 +2,7 @@ package com.youthlink.server.common.security.oauth.handler;
 
 import com.youthlink.server.common.security.JwtProperties;
 import com.youthlink.server.common.security.JwtTokenProvider;
+import com.youthlink.server.domain.member.repository.MemberRepository;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -21,6 +22,7 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
 
     private final JwtTokenProvider jwtTokenProvider;
     private final JwtProperties jwtProperties;
+    private final MemberRepository memberRepository;
 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
@@ -37,18 +39,23 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
         String refreshToken = jwtTokenProvider.createRefreshToken(email);
 
         // RefreshToken을 HttpOnly 쿠키에 저장
-        // refreshTokenExpiration은 ms 단위 → setMaxAge는 초(s) 단위이므로 /1000 변환
         int cookieMaxAge = (int) (jwtProperties.getRefreshTokenExpiration() / 1000);
         Cookie refreshTokenCookie = new Cookie("refreshToken", refreshToken);
-        refreshTokenCookie.setHttpOnly(true); // HTTP 통신 시에만 쿠키 전송 (XSS 공격 방어)
+        refreshTokenCookie.setHttpOnly(true);
         refreshTokenCookie.setSecure(false); // 로컬 테스트용. 운영 환경에서는 반드시 true로 변경
-        refreshTokenCookie.setPath("/"); // 모든 경로에서 쿠키 접근 가능
+        refreshTokenCookie.setPath("/");
         refreshTokenCookie.setMaxAge(cookieMaxAge);
         response.addCookie(refreshTokenCookie);
 
-        // AccessToken을 쿼리 스트링에 담아 프론트엔드로 리다이렉트
+        // 프로필 완성 여부 확인 → 프론트에서 프로필 입력 페이지 분기에 활용
+        boolean isNewMember = memberRepository.findByEmail(email)
+                .map(member -> !member.isProfileComplete())
+                .orElse(true);
+
+        // AccessToken + isNewMember를 쿼리 스트링에 담아 프론트엔드로 리다이렉트
         String targetUrl = UriComponentsBuilder.fromUriString(jwtProperties.getOauth2RedirectUri())
                 .queryParam("accessToken", accessToken)
+                .queryParam("isNewMember", isNewMember)
                 .build().toUriString();
 
         getRedirectStrategy().sendRedirect(request, response, targetUrl);

--- a/src/main/java/com/youthlink/server/domain/member/controller/MemberController.java
+++ b/src/main/java/com/youthlink/server/domain/member/controller/MemberController.java
@@ -1,6 +1,9 @@
 package com.youthlink.server.domain.member.controller;
 
 import com.youthlink.server.common.apipayload.ApiResponse;
+import com.youthlink.server.common.security.CurrentMemberProvider;
+import com.youthlink.server.common.security.code.AuthErrorCode;
+import com.youthlink.server.common.security.exception.AuthException;
 import com.youthlink.server.domain.member.dto.MemberReqDto;
 import com.youthlink.server.domain.member.dto.MemberResDto;
 import com.youthlink.server.domain.member.service.MemberCommandService;
@@ -22,29 +25,34 @@ public class MemberController {
 
     private final MemberQueryService memberQueryService;
     private final MemberCommandService memberCommandService;
+    private final CurrentMemberProvider currentMemberProvider;
 
     @Operation(summary = "내 프로필 조회", description = "현재 로그인한 사용자의 프로필을 조회합니다")
     @GetMapping("/me")
     public ResponseEntity<ApiResponse<MemberResDto.MemberDetailDto>> getMyProfile() {
-        // TODO: SecurityContext에서 인증된 사용자 ID 추출 (OAuth2 연동 후 변경)
+        Long memberId = currentMemberProvider.getCurrentMemberId();
         return ResponseEntity.status(MemberSuccessCode.MEMBER_OK.getStatus())
-                .body(ApiResponse.onSuccess(MemberSuccessCode.MEMBER_OK, memberQueryService.getMemberById(1L)));
+                .body(ApiResponse.onSuccess(MemberSuccessCode.MEMBER_OK, memberQueryService.getMemberById(memberId)));
     }
 
     @Operation(summary = "프로필 수정", description = "현재 로그인한 사용자의 프로필을 수정합니다")
     @PutMapping("/me")
     public ResponseEntity<ApiResponse<MemberResDto.MemberDetailDto>> updateMyProfile(
             @Valid @RequestBody MemberReqDto.ProfileUpdateDto request) {
-        // TODO: SecurityContext에서 인증된 사용자 ID 추출 (OAuth2 연동 후 변경)
+        Long memberId = currentMemberProvider.getCurrentMemberId();
         return ResponseEntity.status(MemberSuccessCode.MEMBER_UPDATE_SUCCESS.getStatus())
                 .body(ApiResponse.onSuccess(MemberSuccessCode.MEMBER_UPDATE_SUCCESS,
-                        memberCommandService.updateProfile(1L, request)));
+                        memberCommandService.updateProfile(memberId, request)));
     }
 
     @Operation(summary = "회원 프로필 조회 (ID)", description = "회원 ID로 프로필을 조회합니다")
     @GetMapping("/{memberId}")
     public ResponseEntity<ApiResponse<MemberResDto.MemberDetailDto>> getMemberProfile(
             @PathVariable Long memberId) {
+        Long currentMemberId = currentMemberProvider.getCurrentMemberId();
+        if (!currentMemberId.equals(memberId)) {
+            throw new AuthException(AuthErrorCode.FORBIDDEN);
+        }
         return ResponseEntity.status(MemberSuccessCode.MEMBER_OK.getStatus())
                 .body(ApiResponse.onSuccess(MemberSuccessCode.MEMBER_OK, memberQueryService.getMemberById(memberId)));
     }

--- a/src/main/java/com/youthlink/server/domain/member/converter/MemberConverter.java
+++ b/src/main/java/com/youthlink/server/domain/member/converter/MemberConverter.java
@@ -2,6 +2,7 @@ package com.youthlink.server.domain.member.converter;
 
 import com.youthlink.server.domain.member.dto.MemberResDto;
 import com.youthlink.server.domain.member.entity.Member;
+import com.youthlink.server.domain.region.entity.Region;
 
 public class MemberConverter {
 
@@ -11,10 +12,23 @@ public class MemberConverter {
                 .email(member.getEmail())
                 .name(member.getName())
                 .age(member.getAge())
-                .region(member.getRegion())
+                .gender(member.getGender())
+                .region(toRegionDto(member.getRegion()))
                 .education(member.getEducation())
                 .employmentStatus(member.getEmploymentStatus())
                 .incomeLevel(member.getIncomeLevel())
+                .isProfileComplete(member.isProfileComplete())
+                .build();
+    }
+
+    private static MemberResDto.RegionDto toRegionDto(Region region) {
+        if (region == null) {
+            return null;
+        }
+        return MemberResDto.RegionDto.builder()
+                .id(region.getId())
+                .sido(region.getSido())
+                .sigungu(region.getSigungu())
                 .build();
     }
 }

--- a/src/main/java/com/youthlink/server/domain/member/dto/MemberReqDto.java
+++ b/src/main/java/com/youthlink/server/domain/member/dto/MemberReqDto.java
@@ -1,19 +1,38 @@
 package com.youthlink.server.domain.member.dto;
 
+import com.youthlink.server.domain.member.enums.EducationLevel;
+import com.youthlink.server.domain.member.enums.Gender;
 import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 public class MemberReqDto {
 
     public record ProfileUpdateDto(
-            @Size(max = 50, message = "이름은 50자 이하여야 합니다") String name,
+            @NotBlank(message = "이름은 필수 입력 값입니다")
+            @Size(max = 50, message = "이름은 50자 이하여야 합니다")
+            String name,
 
-            @Min(value = 1, message = "나이는 1 이상이어야 합니다") Integer age,
+            @NotNull(message = "나이는 필수 입력 값입니다")
+            @Min(value = 1, message = "나이는 1 이상이어야 합니다")
+            Integer age,
 
-            @Size(max = 100, message = "지역은 100자 이하여야 합니다") String region,
+            @NotNull(message = "성별은 필수 입력 값입니다")
+            Gender gender,
 
-            String education,
+            @NotNull(message = "지역 ID는 필수입니다")
+            Long regionId,
+
+            @NotNull(message = "학력 정보는 필수 입력 값입니다")
+            EducationLevel education,
+
+            @NotBlank(message = "고용 상태는 필수 입력 값입니다")
+            @Size(max = 50, message = "고용 상태는 50자 이하여야 합니다")
             String employmentStatus,
+
+            @NotBlank(message = "소득 수준은 필수 입력 값입니다")
+            @Size(max = 50, message = "소득 수준은 50자 이하여야 합니다")
             String incomeLevel) {
     }
 }

--- a/src/main/java/com/youthlink/server/domain/member/dto/MemberResDto.java
+++ b/src/main/java/com/youthlink/server/domain/member/dto/MemberResDto.java
@@ -1,5 +1,7 @@
 package com.youthlink.server.domain.member.dto;
 
+import com.youthlink.server.domain.member.enums.EducationLevel;
+import com.youthlink.server.domain.member.enums.Gender;
 import lombok.Builder;
 
 public class MemberResDto {
@@ -10,9 +12,18 @@ public class MemberResDto {
             String email,
             String name,
             Integer age,
-            String region,
-            String education,
+            Gender gender,
+            RegionDto region,
+            EducationLevel education,
             String employmentStatus,
-            String incomeLevel) {
+            String incomeLevel,
+            boolean isProfileComplete) {
+    }
+
+    @Builder
+    public record RegionDto(
+            Long id,
+            String sido,
+            String sigungu) {
     }
 }

--- a/src/main/java/com/youthlink/server/domain/member/entity/Member.java
+++ b/src/main/java/com/youthlink/server/domain/member/entity/Member.java
@@ -1,14 +1,16 @@
 package com.youthlink.server.domain.member.entity;
 
 import com.youthlink.server.common.base.BaseTimeEntity;
+import com.youthlink.server.domain.member.enums.EducationLevel;
+import com.youthlink.server.domain.member.enums.Gender;
+import com.youthlink.server.domain.region.entity.Region;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Entity
 @Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Member extends BaseTimeEntity {
 
@@ -23,10 +25,17 @@ public class Member extends BaseTimeEntity {
 
     private Integer age;
 
-    private String region;
+    @Enumerated(EnumType.STRING)
+    @Column(length = 10)
+    private Gender gender;
 
-    @Column(length = 50)
-    private String education;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "region_id")
+    private Region region;
+
+    @Enumerated(EnumType.STRING)
+    @Column(length = 30)
+    private EducationLevel education;
 
     @Column(length = 50)
     private String employmentStatus;
@@ -36,24 +45,14 @@ public class Member extends BaseTimeEntity {
 
     private String profileImageUrl;
 
-    @Builder
-    public Member(String email, String name, Integer age, String region,
-            String education, String employmentStatus, String incomeLevel) {
-        this.email = email;
-        this.name = name;
-        this.age = age;
-        this.region = region;
-        this.education = education;
-        this.employmentStatus = employmentStatus;
-        this.incomeLevel = incomeLevel;
-    }
-
-    public void updateProfile(String name, Integer age, String region,
-            String education, String employmentStatus, String incomeLevel) {
+    public void updateProfile(String name, Integer age, Gender gender,
+            Region region, EducationLevel education, String employmentStatus, String incomeLevel) {
         if (name != null)
             this.name = name;
         if (age != null)
             this.age = age;
+        if (gender != null)
+            this.gender = gender;
         if (region != null)
             this.region = region;
         if (education != null)
@@ -62,5 +61,11 @@ public class Member extends BaseTimeEntity {
             this.employmentStatus = employmentStatus;
         if (incomeLevel != null)
             this.incomeLevel = incomeLevel;
+    }
+
+    // 프로필 필수 정보가 모두 입력되었는지 확인
+    // 소셜 로그인 직후에는 email, name만 존재하므로 나머지 필수값이 없으면 프로필 미완성 상태로 판단
+    public boolean isProfileComplete() {
+        return name != null && age != null && gender != null && region != null && education != null;
     }
 }

--- a/src/main/java/com/youthlink/server/domain/member/enums/EducationLevel.java
+++ b/src/main/java/com/youthlink/server/domain/member/enums/EducationLevel.java
@@ -1,0 +1,17 @@
+package com.youthlink.server.domain.member.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum EducationLevel {
+    BELOW_MIDDLE_SCHOOL("중졸 이하"),
+    HIGH_SCHOOL_GRADUATE("고졸"),
+    ASSOCIATE_DEGREE("대졸(전문대)"),
+    BACHELOR_DEGREE("대졸(4년제)"),
+    MASTERS_DEGREE("석사"),
+    DOCTORATE_DEGREE("박사");
+
+    private final String description;
+}

--- a/src/main/java/com/youthlink/server/domain/member/enums/Gender.java
+++ b/src/main/java/com/youthlink/server/domain/member/enums/Gender.java
@@ -1,0 +1,14 @@
+package com.youthlink.server.domain.member.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum Gender {
+
+    MALE("남성"),
+    FEMALE("여성");
+
+    private final String description;
+}

--- a/src/main/java/com/youthlink/server/domain/member/service/MemberCommandServiceImpl.java
+++ b/src/main/java/com/youthlink/server/domain/member/service/MemberCommandServiceImpl.java
@@ -7,6 +7,8 @@ import com.youthlink.server.domain.member.dto.MemberResDto;
 import com.youthlink.server.domain.member.entity.Member;
 import com.youthlink.server.domain.member.exception.MemberException;
 import com.youthlink.server.domain.member.repository.MemberRepository;
+import com.youthlink.server.domain.region.entity.Region;
+import com.youthlink.server.domain.region.repository.RegionRepository;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -18,16 +20,25 @@ import org.springframework.transaction.annotation.Transactional;
 public class MemberCommandServiceImpl implements MemberCommandService {
 
     private final MemberRepository memberRepository;
+    private final RegionRepository regionRepository;
 
     @Override
     public MemberResDto.MemberDetailDto updateProfile(Long memberId, MemberReqDto.ProfileUpdateDto request) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
 
+        // regionId가 전달되었으면 Region 엔티티를 조회하여 연결
+        Region region = null;
+        if (request.regionId() != null) {
+            region = regionRepository.findById(request.regionId())
+                    .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
+        }
+
         member.updateProfile(
                 request.name(),
                 request.age(),
-                request.region(),
+                request.gender(),
+                region,
                 request.education(),
                 request.employmentStatus(),
                 request.incomeLevel());

--- a/src/main/java/com/youthlink/server/domain/region/code/RegionSuccessCode.java
+++ b/src/main/java/com/youthlink/server/domain/region/code/RegionSuccessCode.java
@@ -1,0 +1,17 @@
+package com.youthlink.server.domain.region.code;
+
+import com.youthlink.server.common.apipayload.code.BaseSuccessCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum RegionSuccessCode implements BaseSuccessCode {
+
+    REGION_FOUND(HttpStatus.OK, "REGION200", "지역 목록 조회가 완료되었습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/youthlink/server/domain/region/controller/RegionController.java
+++ b/src/main/java/com/youthlink/server/domain/region/controller/RegionController.java
@@ -1,0 +1,34 @@
+package com.youthlink.server.domain.region.controller;
+
+import com.youthlink.server.common.apipayload.ApiResponse;
+import com.youthlink.server.domain.member.dto.MemberResDto;
+import com.youthlink.server.domain.region.code.RegionSuccessCode;
+import com.youthlink.server.domain.region.converter.RegionConverter;
+import com.youthlink.server.domain.region.entity.Region;
+import com.youthlink.server.domain.region.repository.RegionRepository;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Tag(name = "Region API", description = "지역 관련 API")
+@RestController
+@RequestMapping("/api/regions")
+@RequiredArgsConstructor
+public class RegionController {
+
+    private final RegionRepository regionRepository;
+
+    @Operation(summary = "전체 지역 목록 조회", description = "시/도, 시/군/구 전체 지역 목록을 조회합니다. 프로필 설정 시 드롭다운 구성에 사용합니다.")
+    @GetMapping("")
+    public ResponseEntity<ApiResponse<List<MemberResDto.RegionDto>>> getAllRegions() {
+        List<Region> regions = regionRepository.findAll();
+        return ResponseEntity.status(RegionSuccessCode.REGION_FOUND.getStatus())
+                .body(ApiResponse.onSuccess(RegionSuccessCode.REGION_FOUND, RegionConverter.toRegionDtoList(regions)));
+    }
+}

--- a/src/main/java/com/youthlink/server/domain/region/converter/RegionConverter.java
+++ b/src/main/java/com/youthlink/server/domain/region/converter/RegionConverter.java
@@ -1,0 +1,24 @@
+package com.youthlink.server.domain.region.converter;
+
+import com.youthlink.server.domain.member.dto.MemberResDto;
+import com.youthlink.server.domain.region.entity.Region;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class RegionConverter {
+
+    public static MemberResDto.RegionDto toRegionDto(Region region) {
+        return MemberResDto.RegionDto.builder()
+                .id(region.getId())
+                .sido(region.getSido())
+                .sigungu(region.getSigungu())
+                .build();
+    }
+
+    public static List<MemberResDto.RegionDto> toRegionDtoList(List<Region> regions) {
+        return regions.stream()
+                .map(RegionConverter::toRegionDto)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/youthlink/server/domain/region/entity/Region.java
+++ b/src/main/java/com/youthlink/server/domain/region/entity/Region.java
@@ -1,0 +1,29 @@
+package com.youthlink.server.domain.region.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(uniqueConstraints = @UniqueConstraint(columnNames = {"sido", "sigungu"}))
+public class Region {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 20)
+    private String sido; // 시/도 (예: "서울특별시")
+
+    @Column(nullable = false, length = 20)
+    private String sigungu; // 시/군/구 (예: "강남구")
+
+    // 프롬프트 주입용 지역 문자열 반환.
+    // 예: "서울특별시 강남구"
+    public String toPromptString() {
+        return sido + " " + sigungu;
+    }
+}

--- a/src/main/java/com/youthlink/server/domain/region/repository/RegionRepository.java
+++ b/src/main/java/com/youthlink/server/domain/region/repository/RegionRepository.java
@@ -1,0 +1,7 @@
+package com.youthlink.server.domain.region.repository;
+
+import com.youthlink.server.domain.region.entity.Region;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RegionRepository extends JpaRepository<Region, Long> {
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -29,6 +29,9 @@ spring:
       client:
         registration: {}
 
+  autoconfigure:
+    exclude: org.springframework.ai.vectorstore.chroma.autoconfigure.ChromaVectorStoreAutoConfiguration
+
   ai:
     google:
       genai:
@@ -36,12 +39,17 @@ spring:
         chat:
           options:
             model: gemini-2.5-flash
-    chroma:
-      store:
+        embedding:
+          api-key: test-key
+          options:
+            model: text-embedding-004
+    vectorstore:
+      chroma:
         collection-name: youth_policies
-      client:
-        host: localhost
-        port: 8000
+        initialize-schema: true
+        client:
+          host: http://localhost
+          port: 8000
 
 youth-center:
   api:

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -2,6 +2,30 @@ spring:
   application:
     name: youth-link
 
+  autoconfigure:
+    exclude:
+      - org.springframework.ai.vectorstore.chroma.autoconfigure.ChromaVectorStoreAutoConfiguration
+
+  # Spring AI 로컬 설정 (더미 API 키 - 실제 테스트 시 실제 키로 교체)
+  ai:
+    google:
+      genai:
+        api-key: ${GEMINI_API_KEY:dummy-key}
+        chat:
+          options:
+            model: gemini-2.5-flash
+        embedding:
+          api-key: ${GEMINI_API_KEY:dummy-key}
+          options:
+            model: text-embedding-004
+    vectorstore:
+      chroma:
+        collection-name: youth_policies
+        initialize-schema: true   # 컬렉션 없으면 자동 생성
+        client:
+          host: http://localhost
+          port: 8000
+
   datasource:
     url: jdbc:h2:mem:youth_link;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
     username: sa
@@ -28,28 +52,6 @@ spring:
     oauth2:
       client:
         registration: {}
-
-  autoconfigure:
-    exclude: org.springframework.ai.vectorstore.chroma.autoconfigure.ChromaVectorStoreAutoConfiguration
-
-  ai:
-    google:
-      genai:
-        api-key: test-key
-        chat:
-          options:
-            model: gemini-2.5-flash
-        embedding:
-          api-key: test-key
-          options:
-            model: text-embedding-004
-    vectorstore:
-      chroma:
-        collection-name: youth_policies
-        initialize-schema: true
-        client:
-          host: http://localhost
-          port: 8000
 
 youth-center:
   api:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -47,12 +47,17 @@ spring:
         chat:
           options:
             model: gemini-2.5-flash
-    chroma:
-      store:
+        embedding:
+          api-key: ${GEMINI_API_KEY}
+          options:
+            model: text-embedding-004
+    vectorstore:
+      chroma:
         collection-name: youth_policies
-      client:
-        host: localhost
-        port: 8000
+        initialize-schema: true
+        client:
+          host: http://localhost
+          port: 8000
 
 youth-center:
   api:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -54,7 +54,7 @@ spring:
     vectorstore:
       chroma:
         collection-name: youth_policies
-        initialize-schema: true
+        initialize-schema: true   # 컬렉션 없으면 자동 생성
         client:
           host: http://localhost
           port: 8000


### PR DESCRIPTION
## #️⃣연관된 이슈

## 📝작업 내용

  회원 프로필 설정 기능과 Region 도메인을 구현했습니다.
  
  **Region 도메인 신규 추가**
  - `Region` 엔티티, `RegionController`, `RegionRepository`, `RegionConverter`, `RegionSuccessCode` 추가
  - 지역 목록 조회 API 제공 (프로필 설정 시 지역 선택에 활용)

  **Member 프로필 개편**
  - `Member.region` 필드를 `String → Region` 외래키로 변경
  - `Gender`, `EducationLevel` Enum 분리
  - `Member`에 `@Builder`, `isProfileComplete()` 판별 로직 추가
  - `MemberReqDto.ProfileUpdateDto` 필수 필드 검증 강화 (`@NotNull`, `@NotBlank`)
  - `MemberResDto`에 `RegionDto` 중첩 DTO 및 `gender`, `isProfileComplete` 필드 추가
  - `MemberCommandServiceImpl`: `regionId`로 Region 엔티티를 조회하여 연결

  **OAuth2 로그인 개선** 
  - 로그인 성공 시 `isNewMember` 플래그를 redirect URL에 포함
  - 프론트엔드에서 프로필 미설정 회원 판별 후 프로필 입력 페이지로 분기 가능

  **MemberController 인가 처리**
  - 하드코딩 `1L` 제거, `CurrentMemberProvider`로 인증된 사용자 ID 조회
  - `GET /api/members/{memberId}`에 본인 확인 인가 로직 추가