### PR TITLE
[FEAT] 단일 정책 Chroma 재적재 어드민 API 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '3.4.13'
+	id 'org.springframework.boot' version '3.4.3'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -38,17 +38,24 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'me.paulschwarz:springboot3-dotenv:5.1.0'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6'
+
+	// Spring AI (Google AI Studio Gemini + Chroma Vector Store)
+	implementation platform('org.springframework.ai:spring-ai-bom:1.1.0')
+	implementation 'org.springframework.ai:spring-ai-starter-model-google-genai'
+	implementation 'org.springframework.ai:spring-ai-starter-vector-store-chroma'
+
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 	annotationProcessor 'org.projectlombok:lombok'
+
 	// JWT
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
 
-	// Spring AI - Google GenAI (Gemini API Key 방식 채팅 + 임베딩)
+	// Spring AI - Google GenAI (Gemini 채팅 + 임베딩)
 	implementation 'org.springframework.ai:spring-ai-starter-model-google-genai'
 	// Spring AI - Chroma Vector Store
 	implementation 'org.springframework.ai:spring-ai-starter-vector-store-chroma'

--- a/build.gradle
+++ b/build.gradle
@@ -22,12 +22,11 @@ configurations {
 
 repositories {
 	mavenCentral()
-	maven { url 'https://repo.spring.io/milestone' }
 }
 
 dependencyManagement {
 	imports {
-		mavenBom "org.springframework.ai:spring-ai-bom:1.0.0"
+		mavenBom "org.springframework.ai:spring-ai-bom:1.1.1"
 	}
 }
 
@@ -49,10 +48,10 @@ dependencies {
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
 
-	// Spring AI - Google Gemini (채팅 + 임베딩 모델 자동 구성)
-	implementation 'org.springframework.ai:spring-ai-google-genai-spring-boot-starter'
-	// Spring AI - Chroma Vector Store (VectorStore Bean 자동 구성)
-	implementation 'org.springframework.ai:spring-ai-vectorstore-chroma-spring-boot-starter'
+	// Spring AI - Google GenAI (Gemini API Key 방식 채팅 + 임베딩)
+	implementation 'org.springframework.ai:spring-ai-starter-model-google-genai'
+	// Spring AI - Chroma Vector Store
+	implementation 'org.springframework.ai:spring-ai-starter-vector-store-chroma'
 
 	// XML 파싱 (온통청년 API 응답)
 	implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml'

--- a/src/main/java/com/youthlink/server/ServerApplication.java
+++ b/src/main/java/com/youthlink/server/ServerApplication.java
@@ -13,4 +13,5 @@ public class ServerApplication {
 	public static void main(String[] args) {
 		SpringApplication.run(ServerApplication.class, args);
 	}
+
 }

--- a/src/main/java/com/youthlink/server/ServerApplication.java
+++ b/src/main/java/com/youthlink/server/ServerApplication.java
@@ -12,7 +12,5 @@ public class ServerApplication {
 
 	public static void main(String[] args) {
 		SpringApplication.run(ServerApplication.class, args);
-
-
-
+	}
 }

--- a/src/main/java/com/youthlink/server/domain/policy/code/PolicySuccessCode.java
+++ b/src/main/java/com/youthlink/server/domain/policy/code/PolicySuccessCode.java
@@ -10,7 +10,8 @@ import org.springframework.http.HttpStatus;
 public enum PolicySuccessCode implements BaseSuccessCode {
     POLICY_LIST_OK(HttpStatus.OK, "POLICY200", "정책 목록 조회 성공"),
     POLICY_DETAIL_OK(HttpStatus.OK, "POLICY200", "정책 상세 조회 성공"),
-    POLICY_SYNC_OK(HttpStatus.OK, "POLICY200", "정책 동기화 성공");
+    POLICY_SYNC_OK(HttpStatus.OK, "POLICY200", "정책 동기화 성공"),
+    POLICY_EMBED_OK(HttpStatus.OK, "POLICY200", "정책 임베딩 성공");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/youthlink/server/domain/policy/controller/PolicyController.java
+++ b/src/main/java/com/youthlink/server/domain/policy/controller/PolicyController.java
@@ -9,6 +9,7 @@ import com.youthlink.server.domain.policy.entity.Policy;
 import com.youthlink.server.domain.policy.exception.PolicyException;
 import com.youthlink.server.domain.policy.repository.PolicyRepository;
 import com.youthlink.server.domain.policy.scheduler.DataPipelineScheduler;
+import com.youthlink.server.domain.policy.service.PolicyEmbeddingService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -24,6 +25,7 @@ public class PolicyController {
 
     private final PolicyRepository policyRepository;
     private final DataPipelineScheduler dataPipelineScheduler;
+    private final PolicyEmbeddingService policyEmbeddingService;
 
     @Operation(summary = "정책 목록 조회", description = "수집된 청년 정책 전체 목록을 조회합니다")
     @GetMapping("/api/policies")
@@ -52,5 +54,16 @@ public class PolicyController {
         dataPipelineScheduler.syncManually();
         return ResponseEntity.status(PolicySuccessCode.POLICY_SYNC_OK.getStatus())
                 .body(ApiResponse.onSuccess(PolicySuccessCode.POLICY_SYNC_OK, null));
+    }
+
+    @Operation(summary = "단일 정책 Chroma 재적재",
+            description = "특정 정책 1건을 Chroma에 다시 임베딩합니다. 전체 파이프라인 없이 특정 정책만 수정된 경우 사용합니다.")
+    @PostMapping("/api/admin/policies/{policyId}/embed")
+    public ResponseEntity<ApiResponse<Void>> reEmbedPolicy(@PathVariable Long policyId) {
+        Policy policy = policyRepository.findById(policyId)
+                .orElseThrow(() -> new PolicyException(PolicyErrorCode.POLICY_NOT_FOUND));
+        policyEmbeddingService.embedPolicies(List.of(policy));
+        return ResponseEntity.status(PolicySuccessCode.POLICY_EMBED_OK.getStatus())
+                .body(ApiResponse.onSuccess(PolicySuccessCode.POLICY_EMBED_OK, null));
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용
  전체 파이프라인 없이 특정 정책 1건만 Chroma에 재적재할 수 있는 어드민 API를 추가했습니다.
  
  - `POST /api/admin/policies/{policyId}/embed` 엔드포인트 추가
  - `PolicySuccessCode`에 `POLICY_EMBED_OK` 추가
  - `@EnableScheduling` 복원 (develop에서 실수로 제거된 것 수정, DataPipelineScheduler 정상 동작에 필수)
  - Spring AI BOM `1.0.0 → 1.1.1` 업그레이드, 아티팩트 명칭을 정식 명칭으로 변경
    - `spring-ai-google-genai-spring-boot-starter` → `spring-ai-starter-model-google-genai`
    - `spring-ai-vectorstore-chroma-spring-boot-starter` → `spring-ai-starter-vector-store-chroma`
  - Milestone 레포지토리 제거 (1.1.1부터 Maven Central 정식 배포)